### PR TITLE
fix typo: label

### DIFF
--- a/internal/lb/round_robin.go
+++ b/internal/lb/round_robin.go
@@ -15,7 +15,7 @@ type Node struct {
 func (n *Node) BlockForSomeTime() {
 	// TODO: make this configurable
 	n.BlockTimes.Add(1000)
-	logger.Infof("[lb] block remote node for 1000 times lable=%s remote=%s", n.Label, n.Address)
+	logger.Infof("[lb] block remote node for 1000 times label=%s remote=%s", n.Label, n.Address)
 }
 
 // RoundRobin is an interface for representing round-robin balancing.


### PR DESCRIPTION
另外还有一个点是默认 RelayConfig 没有 Label，打印出来前面会带个负号：

```
lable=-{目标地址}:6379
```