### PR TITLE
ci: optimize build

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -10,6 +10,9 @@ on:
       - "pkg/**"
   workflow_dispatch:
 
+env:
+  REGISTRY_IMAGE: ehco1996/ehco
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -41,14 +44,61 @@ jobs:
       - name: test
         run: make test
 
-      - name: build
-        run: make build
-
-  build-latest-image:
+  build-bin:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
     steps:
-      - uses: actions/checkout@master
+      - name: Set up Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: "1.21"
+        id: go
+
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v1
+
+      - name: build
+        run: |
+          mkdir -p /tmp/ehco
+          make build
+          mv ./dist/ehco /tmp/ehco/ehco-amd64
+          make build-arm
+          mv ./dist/ehco /tmp/ehco/ehco-arm64
+          cp ./build/Dockerfile /tmp/ehco/Dockerfile
+
+      - name: Upload binaries
+        uses: actions/upload-artifact@v3
+        with:
+          name: binaries
+          path: /tmp/ehco
+          if-no-files-found: error
+          retention-days: 1
+
+  build:
+    runs-on: ubuntu-latest
+    needs:
+      - build-bin
+    strategy:
+      fail-fast: true
+      matrix:
+        platform: [amd64, arm64]
+    steps:
+      - name: Download binaries
+        uses: actions/download-artifact@v3
+        with:
+          name: binaries
+          path: /tmp/ehco
+      - name: rename the binary
+        run: |
+          cp /tmp/ehco/ehco-${{ matrix.platform }} /tmp/ehco/ehco
 
       - name: set up qemu
         uses: docker/setup-qemu-action@v2
@@ -64,9 +114,57 @@ jobs:
 
       - name: Build multi-platform image
         uses: docker/build-push-action@v4
+        id: build
         with:
-          context: .
-          tags: "ehco1996/ehco:latest,ehco1996/ehco:${{ github.sha }}"
-          push: true
-          file: build/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          context: /tmp/ehco
+          file: /tmp/ehco/Dockerfile
+          platforms: linux/${{ matrix.platform }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"          
+      - name: Upload digest
+        uses: actions/upload-artifact@v3
+        with:
+          name: digests
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v3
+        with:
+          name: digests
+          path: /tmp/digests
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+          tags: |
+            type=sha
+            type=raw,value=latest
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ FAIL_ON_STDOUT := awk '{ print } END { if (NR > 0) { exit 1 } }'
 # -w -s 参数的解释：You will get the smallest binaries if you compile with -ldflags '-w -s'. The -w turns off DWARF debugging information
 # for more information, please refer to https://stackoverflow.com/questions/22267189/what-does-the-w-flag-mean-when-passed-in-via-the-ldflags-option-to-the-go-comman
 # we need CGO_ENABLED=1 because we import the node_exporter ,and we need install `glibc-source,libc6` to make it work
-GOBUILD=CGO_ENABLED=1 go build -trimpath -ldflags="-w -s -X ${PACKAGE}.GitBranch=${BRANCH} -X ${PACKAGE}.GitRevision=${REVISION} -X ${PACKAGE}.BuildTime=${BUILDTIME}"
+GOBUILD=CGO_ENABLED=0 go build -trimpath -ldflags="-w -s -X ${PACKAGE}.GitBranch=${BRANCH} -X ${PACKAGE}.GitRevision=${REVISION} -X ${PACKAGE}.BuildTime=${BUILDTIME}"
 
 tools:
 	@echo "run setup tools"

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,11 +1,3 @@
-FROM golang:1.21 as builder
-WORKDIR /app
-COPY . .
-
-RUN --mount=type=cache,target=/home/runner/go/pkg/mod \
-    --mount=type=cache,target=/home/runner/.cache/go-build \
-    make build
-
 FROM debian:12-slim
 
 RUN apt update && apt install -y --no-install-recommends ca-certificates curl glibc-source libc6
@@ -13,6 +5,7 @@ RUN apt update && apt install -y --no-install-recommends ca-certificates curl gl
 WORKDIR /bin/
 
 # Copy the pre-built binary file from the previous stage
-COPY --from=builder /app/dist/ehco .
+COPY ehco .
+RUN chmod +x ehco
 
 ENTRYPOINT ["ehco"]


### PR DESCRIPTION
~cd 的改动暂时放在 `.github/workflows/optimize-build.yaml` 里方便推分支的时候测试，没问题的话就迁移到 cd.yaml 里去~

# 改动

1. 用 go build 时的 GOARCH 来编译出不同平台的二进制，而不是在 qemu 环境里 build。qemu 的性能太差，在 action 里无论怎么优化也要跑十分钟以上。
2. Dockerfile 中改为只是把二进制 COPY 进来
    - 如果说为了方便用户自己本地 build 镜像还是要保留一个正常的多阶段的 Dockerfile 的话，这个改动后的可以叫 `cd.Dockerfile`
3. 分不同的 job 来 build 不同平台然后 merge 成一个镜像一起推上去
    - 参考的官网文档的做法 https://docs.docker.com/build/ci/github-actions/multi-platform/
    - 镜像 tag 是在 merge 任务里的 Docker meta 步骤配置的

然后还有这些被迫的改动：
- Makefile 里 `CGO_ENABLED=0`，因为 CGO 开了不能交叉编译
- Dockerfile 里加了句 `RUN chmod +x ehco` 因为不知道为啥拷过去的二进制没有执行权限

# 效果

## cd 总时间从十几分钟缩短到四分钟
![image](https://github.com/Ehco1996/ehco/assets/10897528/1401bd51-62e4-44e5-bdb1-b946ed97a871)

## 同样 tag 的镜像是多平台的（不过我没有 arm 的 linux 设备可以测试）
![image](https://github.com/Ehco1996/ehco/assets/10897528/05a8cc4c-1a7d-41c1-8ba4-346d711ffaf6)
