### PR TITLE
fix: fix the graceful exit handling logic

### DIFF
--- a/cmd/ehco/main.go
+++ b/cmd/ehco/main.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/Ehco1996/ehco/internal/cli"
-	"github.com/getsentry/sentry-go"
+	sentry "github.com/getsentry/sentry-go"
 )
 
 func main() {


### PR DESCRIPTION
Use [signal.NotifyContext](https://pkg.go.dev/os/signal#NotifyContext) to handle os signal.

CLOSED: #297