### PR TITLE
feat(ci): replace set-output with $GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -26,7 +26,8 @@ jobs:
     steps:
       - id: set-matrix
         run: |
-          echo '::set-output name=matrix::{"platform":["amd64","arm64"]}'
+          echo '{"platform": ["amd64", "arm64"]}' > matrix.json
+          echo "matrix=$(cat matrix.json)" >> $GITHUB_OUTPUT
 
   build-bin:
     runs-on: ubuntu-latest


### PR DESCRIPTION
set-output was deprecated due to security concerns: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/