### PR TITLE
build/cli: inject Version from nightly tag, plus show help on bare `ehco`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,28 @@ BUILDTIME=$(shell date +"%Y-%m-%d-%T")
 BRANCH=$(shell git rev-parse --abbrev-ref HEAD | tr -d '\040\011\012\015\n')
 REVISION=$(shell git rev-parse HEAD)
 
+# Derive a semver-valid VERSION from git so `make build` (and Docker, etc.)
+# produces binaries that self-report something newer than the most recent
+# stable tag. goreleaser already injects its own VERSION via GORELEASER_CURRENT_TAG,
+# so this only matters for non-goreleaser builds.
+#
+# Output shape:
+#   - on a stable tag exactly        -> X.Y.Z          (e.g. 1.1.6)
+#   - N commits past last stable tag -> X.Y.Z-dev.N+gSHA (e.g. 1.1.6-dev.8+gabc1234)
+#   - no stable tag reachable        -> falls back to constant.Version source default
+GIT_LAST_STABLE := $(shell git describe --tags --abbrev=0 --match 'v*' --exclude='*-*' 2>/dev/null)
+GIT_LAST_STABLE_VER := $(patsubst v%,%,$(GIT_LAST_STABLE))
+GIT_AHEAD := $(shell test -n "$(GIT_LAST_STABLE)" && git rev-list --count $(GIT_LAST_STABLE)..HEAD 2>/dev/null || echo 0)
+GIT_SHORT_SHA := $(shell git rev-parse --short=7 HEAD 2>/dev/null)
+
+ifeq ($(GIT_LAST_STABLE),)
+VERSION_LDFLAG :=
+else ifeq ($(GIT_AHEAD),0)
+VERSION_LDFLAG := -X $(PACKAGE).Version=$(GIT_LAST_STABLE_VER)
+else
+VERSION_LDFLAG := -X $(PACKAGE).Version=$(GIT_LAST_STABLE_VER)-dev.$(GIT_AHEAD)+g$(GIT_SHORT_SHA)
+endif
+
 
 PACKAGE_LIST  := go list ./...
 FILES         := $(shell find . -name "*.go" -type f)
@@ -24,7 +46,7 @@ endif
 
 # -w -s 参数的解释：You will get the smallest binaries if you compile with -ldflags '-w -s'. The -w turns off DWARF debugging information
 # for more information, please refer to https://stackoverflow.com/questions/22267189/what-does-the-w-flag-mean-when-passed-in-via-the-ldflags-option-to-the-go-comman
-GOBUILD=CGO_ENABLED=0 go build -tags ${BUILD_TAG_FOR_NODE_EXPORTER} -trimpath -ldflags="-w -s -X ${PACKAGE}.GitBranch=${BRANCH} -X ${PACKAGE}.GitRevision=${REVISION} -X ${PACKAGE}.BuildTime=${BUILDTIME}"
+GOBUILD=CGO_ENABLED=0 go build -tags ${BUILD_TAG_FOR_NODE_EXPORTER} -trimpath -ldflags="-w -s ${VERSION_LDFLAG} -X ${PACKAGE}.GitBranch=${BRANCH} -X ${PACKAGE}.GitRevision=${REVISION} -X ${PACKAGE}.BuildTime=${BUILDTIME}"
 
 
 tools:

--- a/Makefile
+++ b/Makefile
@@ -8,26 +8,23 @@ BUILDTIME=$(shell date +"%Y-%m-%d-%T")
 BRANCH=$(shell git rev-parse --abbrev-ref HEAD | tr -d '\040\011\012\015\n')
 REVISION=$(shell git rev-parse HEAD)
 
-# Derive a semver-valid VERSION from git so `make build` (and Docker, etc.)
-# produces binaries that self-report something newer than the most recent
-# stable tag. goreleaser already injects its own VERSION via GORELEASER_CURRENT_TAG,
-# so this only matters for non-goreleaser builds.
+# Pin VERSION to the most recent nightly tag so `make build` (and Docker, etc.)
+# self-reports the current in-progress release line, e.g. `1.1.7-next` while
+# v1.1.7 is being prepared. goreleaser still injects its own GORELEASER_CURRENT_TAG
+# for actual release artifacts; this only kicks in for non-goreleaser builds.
 #
-# Output shape:
-#   - on a stable tag exactly        -> X.Y.Z          (e.g. 1.1.6)
-#   - N commits past last stable tag -> X.Y.Z-dev.N+gSHA (e.g. 1.1.6-dev.8+gabc1234)
-#   - no stable tag reachable        -> falls back to constant.Version source default
-GIT_LAST_STABLE := $(shell git describe --tags --abbrev=0 --match 'v*' --exclude='*-*' 2>/dev/null)
-GIT_LAST_STABLE_VER := $(patsubst v%,%,$(GIT_LAST_STABLE))
-GIT_AHEAD := $(shell test -n "$(GIT_LAST_STABLE)" && git rev-list --count $(GIT_LAST_STABLE)..HEAD 2>/dev/null || echo 0)
-GIT_SHORT_SHA := $(shell git rev-parse --short=7 HEAD 2>/dev/null)
+# Resolution order:
+#   1. nearest reachable nightly tag matching v*-next
+#   2. nearest reachable stable tag (rare: only between a release and the next nightly cron)
+#   3. empty -> falls back to the constant.Version source default
+GIT_DESCRIBE_VERSION := $(shell git describe --tags --abbrev=0 --match 'v*-next' 2>/dev/null \
+	|| git describe --tags --abbrev=0 --match 'v*' --exclude='*-*' 2>/dev/null)
+VERSION := $(patsubst v%,%,$(GIT_DESCRIBE_VERSION))
 
-ifeq ($(GIT_LAST_STABLE),)
+ifeq ($(VERSION),)
 VERSION_LDFLAG :=
-else ifeq ($(GIT_AHEAD),0)
-VERSION_LDFLAG := -X $(PACKAGE).Version=$(GIT_LAST_STABLE_VER)
 else
-VERSION_LDFLAG := -X $(PACKAGE).Version=$(GIT_LAST_STABLE_VER)-dev.$(GIT_AHEAD)+g$(GIT_SHORT_SHA)
+VERSION_LDFLAG := -X $(PACKAGE).Version=$(VERSION)
 endif
 
 

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -13,6 +13,13 @@ import (
 var cliLogger = log.MustNewLogger("info").Sugar().Named("cli")
 
 func startAction(ctx *cli.Context) error {
+	// No subcommand and no config source given -> the user almost certainly
+	// just typed `ehco` to see what it does. Show help instead of fataling
+	// with "invalid listen".
+	if ConfigPath == "" && LocalAddr == "" {
+		return cli.ShowAppHelp(ctx)
+	}
+
 	cfg, err := InitConfigAndComponents()
 	if err != nil {
 		cliLogger.Fatalf("InitConfigAndComponents meet err=%s", err.Error())

--- a/internal/constant/constant.go
+++ b/internal/constant/constant.go
@@ -5,7 +5,11 @@ import "time"
 type RelayType string
 
 var (
-	Version     = "1.1.6"
+	// Version is overridden at link time by Makefile / goreleaser ldflags.
+	// The literal here is a fallback for raw `go build` invocations on master,
+	// kept slightly newer than the most recent stable tag so the update
+	// command's nightly auto-detection and downgrade guard behave sanely.
+	Version     = "1.1.7-next"
 	GitBranch   string
 	GitRevision string
 	BuildTime   string


### PR DESCRIPTION
Two small follow-ups to #440 in one PR.

## 1. Inject `Version` for non-goreleaser builds

The `Makefile` ldflags injected `GitBranch / GitRevision / BuildTime` but **not `Version`**, so any binary produced by `make build` (Docker images included) self-reported as the literal `"1.1.6"` baked into `internal/constant/constant.go`. That defeats the update command's nightly auto-detection: a post-1.1.6 master binary looked identical to released v1.1.6 and would either silently no-op or get rolled backward.

Pin the injected `Version` to the most recent reachable nightly tag so `make build` matches the convention enforced by `.github/workflows/nightly.yml` (master between v1.1.6 and v1.1.7 → reports `1.1.7-next`, matching the rolling nightly artifact).

Resolution order:
1. nearest reachable `v*-next` tag (normal case → `1.1.7-next`)
2. nearest reachable stable tag (the brief window between a release and the next nightly cron)
3. empty → falls back to the `constant.Version` source default

`goreleaser` paths are unaffected — they keep injecting their own `GORELEASER_CURRENT_TAG`.

Source-default `Version` also bumped from `1.1.6` to `1.1.7-next` so raw `go build cmd/ehco/main.go` (no Makefile, no goreleaser) on master still self-identifies as the current nightly line.

## 2. `ehco` with no args prints help instead of fataling

Running bare `ehco` (no `-c`, no `-l`, no env) used to fall through to `startAction` -> `InitConfigAndComponents` -> `Fatalf("invalid listen")`. Confusing for a first-time user. Detect "no config source given" up front and print app help instead.

## Test plan

- [x] `make build` on this branch reports `Version=1.1.7-next` (verified locally)
- [x] `./dist/ehco` with no args prints app help and exits 0 (verified locally)
- [x] All generated version strings pass `golang.org/x/mod/semver.IsValid`
- [x] `go vet ./...` clean
- [ ] On a server, `make build` + `./dist/ehco update` should: auto-detect nightly channel, fetch latest `v*-next` release, semver-compare and either upgrade or report "already up to date"
- [ ] Existing flows unchanged: `ehco -c <path>`, `ehco -l ... -r ...`, env-var-only invocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)