### PR TITLE
auth: cookie sessions + bearer-header machine auth

### DIFF
--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -25,7 +25,8 @@ func loadConfig() (cfg *config.Config, err error) {
 	} else {
 		cfg = &config.Config{
 			WebPort:        WebPort,
-			WebToken:       WebToken,
+			DashboardPass:  DashboardPass,
+			ApiToken:       ApiToken,
 			EnablePing:     EnablePing,
 			PATH:           ConfigPath,
 			LogLeveL:       LogLevel,

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -13,7 +13,8 @@ var (
 	TransportType        constant.RelayType
 	ConfigPath           string
 	WebPort              int
-	WebToken             string
+	DashboardPass        string
+	ApiToken             string
 	EnablePing           bool
 	SystemFilePath       = "/etc/systemd/system/ehco.service"
 	LogLevel             string
@@ -70,10 +71,16 @@ var RootFlags = []cli.Flag{
 		Destination: &EnablePing,
 	},
 	&cli.StringFlag{
-		Name:        "web_token",
-		Usage:       "如果访问webui时不带着正确的token，会直接reset连接",
-		EnvVars:     []string{"EHCO_WEB_TOKEN"},
-		Destination: &WebToken,
+		Name:        "dashboard_pass",
+		Usage:       "ehco 内置面板登录密码 (留空则关闭面板登录)",
+		EnvVars:     []string{"EHCO_DASHBOARD_PASS"},
+		Destination: &DashboardPass,
+	},
+	&cli.StringFlag{
+		Name:        "api_token",
+		Usage:       "非浏览器调用方走 Authorization: Bearer 时使用的 token",
+		EnvVars:     []string{"EHCO_API_TOKEN"},
+		Destination: &ApiToken,
 	},
 	&cli.StringFlag{
 		Name:        "log_level",

--- a/internal/cmgr/cmgr.go
+++ b/internal/cmgr/cmgr.go
@@ -64,7 +64,7 @@ func NewCmgr(cfg *Config) (Cmgr, error) {
 		closedConnectionsMap: make(map[string][]conn.RelayConn),
 	}
 	if cfg.NeedMetrics() {
-		cmgr.mr = metric_reader.NewReader(cfg.MetricsURL)
+		cmgr.mr = metric_reader.NewReader(cfg.MetricsURL, cfg.ApiToken)
 
 		homeDir, _ := os.UserHomeDir()
 		dbPath := filepath.Join(homeDir, ".ehco", "metrics.db")

--- a/internal/cmgr/config.go
+++ b/internal/cmgr/config.go
@@ -3,7 +3,8 @@ package cmgr
 type Config struct {
 	SyncURL      string
 	MetricsURL   string
-	SyncInterval int // in seconds
+	ApiToken     string // bearer token for authed local /metrics/ pull
+	SyncInterval int    // in seconds
 }
 
 func (c *Config) NeedSync() bool {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,9 +18,22 @@ import (
 type Config struct {
 	PATH string `json:"-"`
 
-	NodeLabel   string `json:"node_label,omitempty"`
-	WebHost     string `json:"web_host,omitempty"`
-	WebPort     int    `json:"web_port,omitempty"`
+	NodeLabel string `json:"node_label,omitempty"`
+	WebHost   string `json:"web_host,omitempty"`
+	WebPort   int    `json:"web_port,omitempty"`
+
+	// Dashboard login password for the embedded SPA. The username is
+	// implicit (single-tenant); only the password is configured.
+	DashboardPass string `json:"dashboard_pass,omitempty"`
+	// Bearer token for non-browser callers (mizhiwu reload client,
+	// scrapers, curl). Sent via Authorization: Bearer or X-Ehco-Token.
+	ApiToken string `json:"api_token,omitempty"`
+
+	// Legacy fields kept so a config file or upstream JSON written for
+	// the previous (KeyAuth + BasicAuth) auth scheme still works. The
+	// loader in Adjust() folds these onto DashboardPass / ApiToken if
+	// the new fields are empty. WebAuthUser is intentionally accepted
+	// but ignored — the new scheme has no separate username.
 	WebToken    string `json:"web_token,omitempty"`
 	WebAuthUser string `json:"web_auth_user,omitempty"`
 	WebAuthPass string `json:"web_auth_pass,omitempty"`
@@ -94,6 +107,16 @@ func (c *Config) Adjust() error {
 	if c.WebHost == "" {
 		c.WebHost = "0.0.0.0"
 	}
+	// Fold legacy fields onto the new ones. Done here (post-decode,
+	// pre-validation) so every code path that calls LoadConfig sees
+	// the same shape regardless of whether the source JSON came from
+	// a current or pre-cookie-auth mizhiwu serializer.
+	if c.DashboardPass == "" && c.WebAuthPass != "" {
+		c.DashboardPass = c.WebAuthPass
+	}
+	if c.ApiToken == "" && c.WebToken != "" {
+		c.ApiToken = c.WebToken
+	}
 
 	for _, r := range c.RelayConfigs {
 		if err := r.Validate(); err != nil {
@@ -141,13 +164,8 @@ func (c *Config) GetMetricURL() string {
 	if !c.NeedStartWebServer() {
 		return ""
 	}
-	url := fmt.Sprintf("http://%s:%d/metrics/", c.WebHost, c.WebPort)
-	if c.WebToken != "" {
-		url += fmt.Sprintf("?token=%s", c.WebToken)
-	}
-	// for basic auth
-	if c.WebAuthUser != "" && c.WebAuthPass != "" {
-		url = fmt.Sprintf("http://%s:%s@%s:%d/metrics/", c.WebAuthUser, c.WebAuthPass, c.WebHost, c.WebPort)
-	}
-	return url
+	// Plain URL: no creds in query, no creds in basic-auth userinfo.
+	// Internal callers attach Authorization: Bearer <ApiToken> as a
+	// header instead — see metric_reader / bandwidth_recorder.
+	return fmt.Sprintf("http://%s:%d/metrics/", c.WebHost, c.WebPort)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,15 +29,6 @@ type Config struct {
 	// scrapers, curl). Sent via Authorization: Bearer or X-Ehco-Token.
 	ApiToken string `json:"api_token,omitempty"`
 
-	// Legacy fields kept so a config file or upstream JSON written for
-	// the previous (KeyAuth + BasicAuth) auth scheme still works. The
-	// loader in Adjust() folds these onto DashboardPass / ApiToken if
-	// the new fields are empty. WebAuthUser is intentionally accepted
-	// but ignored — the new scheme has no separate username.
-	WebToken    string `json:"web_token,omitempty"`
-	WebAuthUser string `json:"web_auth_user,omitempty"`
-	WebAuthPass string `json:"web_auth_pass,omitempty"`
-
 	LogLeveL       string `json:"log_level,omitempty"`
 	EnablePing     bool   `json:"enable_ping,omitempty"`
 	ReloadInterval int    `json:"reload_interval,omitempty"`
@@ -106,16 +97,6 @@ func (c *Config) Adjust() error {
 	}
 	if c.WebHost == "" {
 		c.WebHost = "0.0.0.0"
-	}
-	// Fold legacy fields onto the new ones. Done here (post-decode,
-	// pre-validation) so every code path that calls LoadConfig sees
-	// the same shape regardless of whether the source JSON came from
-	// a current or pre-cookie-auth mizhiwu serializer.
-	if c.DashboardPass == "" && c.WebAuthPass != "" {
-		c.DashboardPass = c.WebAuthPass
-	}
-	if c.ApiToken == "" && c.WebToken != "" {
-		c.ApiToken = c.WebToken
 	}
 
 	for _, r := range c.RelayConfigs {

--- a/internal/relay/server.go
+++ b/internal/relay/server.go
@@ -33,6 +33,7 @@ func NewServer(cfg *config.Config) (*Server, error) {
 		SyncURL:      cfg.RelaySyncURL,
 		SyncInterval: cfg.RelaySyncInterval,
 		MetricsURL:   cfg.GetMetricURL(),
+		ApiToken:     cfg.ApiToken,
 	}
 	cmgrCfg.Adjust()
 	cmgr, err := cmgr.NewCmgr(cmgrCfg)

--- a/internal/web/auth.go
+++ b/internal/web/auth.go
@@ -1,0 +1,240 @@
+package web
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"go.uber.org/zap"
+
+	"github.com/Ehco1996/ehco/internal/config"
+)
+
+const (
+	sessionCookieName = "ehco_sid"
+	sessionTTL        = 7 * 24 * time.Hour
+	bearerHeader      = "Authorization"
+	bearerPrefix      = "Bearer "
+	apiTokenHeader    = "X-Ehco-Token"
+)
+
+// sessionStore is an in-memory sid → expiry map. We accept loss-on-restart
+// because the dashboard is a low-frequency tool and the fleet is small;
+// users re-login after a binary upgrade. No persistence layer (sqlite,
+// Redis, …) is worth the operational weight at this scale.
+type sessionStore struct {
+	mu       sync.Mutex
+	sessions map[string]time.Time
+}
+
+func newSessionStore() *sessionStore {
+	return &sessionStore{sessions: make(map[string]time.Time)}
+}
+
+func (s *sessionStore) issue() (string, time.Time, error) {
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		return "", time.Time{}, err
+	}
+	sid := base64.RawURLEncoding.EncodeToString(buf)
+	expiry := time.Now().Add(sessionTTL)
+	s.mu.Lock()
+	s.sessions[sid] = expiry
+	s.mu.Unlock()
+	return sid, expiry, nil
+}
+
+// validate returns (ok, newExpiry). Sliding refresh: every successful
+// hit pushes the expiry back to now+TTL so an actively used session
+// doesn't expire while the user is on the page.
+func (s *sessionStore) validate(sid string) (bool, time.Time) {
+	if sid == "" {
+		return false, time.Time{}
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	exp, ok := s.sessions[sid]
+	if !ok {
+		return false, time.Time{}
+	}
+	now := time.Now()
+	if now.After(exp) {
+		delete(s.sessions, sid)
+		return false, time.Time{}
+	}
+	newExp := now.Add(sessionTTL)
+	s.sessions[sid] = newExp
+	return true, newExp
+}
+
+func (s *sessionStore) revoke(sid string) {
+	if sid == "" {
+		return
+	}
+	s.mu.Lock()
+	delete(s.sessions, sid)
+	s.mu.Unlock()
+}
+
+// authenticator combines the session store with config-driven bearer-token
+// validation. One type owns both because the middleware needs to ask
+// "is this request authenticated?" and the answer can come from either side.
+type authenticator struct {
+	cfg      *config.Config
+	sessions *sessionStore
+	l        *zap.SugaredLogger
+}
+
+func newAuthenticator(cfg *config.Config) *authenticator {
+	return &authenticator{
+		cfg:      cfg,
+		sessions: newSessionStore(),
+		l:        zap.S().Named("auth"),
+	}
+}
+
+// authRequired reports whether dashboard auth is configured at all.
+// When false (no DashboardPass, no ApiToken), the dashboard is fully
+// open — used in dev / fresh deployments where credentials haven't
+// been pushed yet.
+func (a *authenticator) authRequired() bool {
+	return a.cfg.DashboardPass != "" || a.cfg.ApiToken != ""
+}
+
+// checkRequest tries cookie session, then bearer header, then x-ehco-token.
+// Returns (authenticated, sidToRefresh). If sidToRefresh is non-empty
+// the middleware should re-issue the cookie with the slid expiry.
+func (a *authenticator) checkRequest(r *http.Request) (bool, string, time.Time) {
+	if !a.authRequired() {
+		return true, "", time.Time{}
+	}
+
+	// 1. Cookie — preferred for browsers.
+	if c, err := r.Cookie(sessionCookieName); err == nil {
+		if ok, exp := a.sessions.validate(c.Value); ok {
+			return true, c.Value, exp
+		}
+	}
+
+	// 2. Bearer header — preferred for machine clients.
+	if a.cfg.ApiToken != "" {
+		if h := r.Header.Get(bearerHeader); strings.HasPrefix(h, bearerPrefix) {
+			supplied := strings.TrimPrefix(h, bearerPrefix)
+			if subtle.ConstantTimeCompare([]byte(supplied), []byte(a.cfg.ApiToken)) == 1 {
+				return true, "", time.Time{}
+			}
+		}
+		if h := r.Header.Get(apiTokenHeader); h != "" {
+			if subtle.ConstantTimeCompare([]byte(h), []byte(a.cfg.ApiToken)) == 1 {
+				return true, "", time.Time{}
+			}
+		}
+	}
+
+	return false, "", time.Time{}
+}
+
+// authMiddleware enforces the auth rules globally except for paths
+// listed in isPublicPath. When auth is not configured the middleware
+// is a no-op pass-through.
+func (a *authenticator) authMiddleware() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			if isPublicPath(c.Request().URL.Path) {
+				return next(c)
+			}
+			ok, sid, exp := a.checkRequest(c.Request())
+			if !ok {
+				return echo.NewHTTPError(http.StatusUnauthorized, "authentication required")
+			}
+			if sid != "" {
+				// Slide cookie expiry. Keeps long-living dashboard tabs alive.
+				setSessionCookie(c, sid, exp)
+			}
+			return next(c)
+		}
+	}
+}
+
+// setSessionCookie writes the sid cookie with attributes that match the
+// connection. Secure is conditional on the request being over TLS; we
+// can't unconditionally set it because the dashboard is also reachable
+// over plain HTTP on the tailnet.
+func setSessionCookie(c echo.Context, sid string, expiry time.Time) {
+	cookie := &http.Cookie{
+		Name:     sessionCookieName,
+		Value:    sid,
+		Path:     "/",
+		Expires:  expiry,
+		HttpOnly: true,
+		SameSite: http.SameSiteStrictMode,
+		Secure:   c.IsTLS(),
+	}
+	c.SetCookie(cookie)
+}
+
+func clearSessionCookie(c echo.Context) {
+	cookie := &http.Cookie{
+		Name:     sessionCookieName,
+		Value:    "",
+		Path:     "/",
+		Expires:  time.Unix(0, 0),
+		MaxAge:   -1,
+		HttpOnly: true,
+		SameSite: http.SameSiteStrictMode,
+		Secure:   c.IsTLS(),
+	}
+	c.SetCookie(cookie)
+}
+
+// loginRequest is the body of POST /api/v1/auth/login. We ignore any
+// "user" field a client might send — single-tenant, password only.
+type loginRequest struct {
+	Password string `json:"password"`
+}
+
+// HandleLogin authenticates against cfg.DashboardPass and, on success,
+// issues a session cookie. Public endpoint.
+func (s *Server) HandleLogin(c echo.Context) error {
+	if !s.auth.authRequired() {
+		// No password configured — login is meaningless. Don't 401, but
+		// don't issue a session either; the SPA already knows from
+		// /auth/info that nothing's required.
+		return c.JSON(http.StatusOK, map[string]any{"authenticated": true})
+	}
+	if s.cfg.DashboardPass == "" {
+		// ApiToken is set but DashboardPass isn't — machine-only deployment.
+		// Browsers can't log in.
+		return echo.NewHTTPError(http.StatusForbidden, "dashboard login not configured")
+	}
+	var req loginRequest
+	if err := json.NewDecoder(c.Request().Body).Decode(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid login body")
+	}
+	if subtle.ConstantTimeCompare([]byte(req.Password), []byte(s.cfg.DashboardPass)) != 1 {
+		return echo.NewHTTPError(http.StatusUnauthorized, "invalid password")
+	}
+	sid, exp, err := s.auth.sessions.issue()
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to issue session")
+	}
+	setSessionCookie(c, sid, exp)
+	return c.JSON(http.StatusOK, map[string]any{"authenticated": true})
+}
+
+// HandleLogout revokes the session and clears the cookie. Idempotent —
+// safe to call from any state. Public endpoint so the SPA can sign out
+// even if the cookie was somehow lost.
+func (s *Server) HandleLogout(c echo.Context) error {
+	if cookie, err := c.Request().Cookie(sessionCookieName); err == nil {
+		s.auth.sessions.revoke(cookie.Value)
+	}
+	clearSessionCookie(c)
+	return c.JSON(http.StatusOK, map[string]any{"authenticated": false})
+}

--- a/internal/web/auth_test.go
+++ b/internal/web/auth_test.go
@@ -1,0 +1,173 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/Ehco1996/ehco/internal/config"
+)
+
+// helper: minimal echo + auth wired up, no dashboard routes. The test
+// targets the middleware in isolation rather than the full Server,
+// because the full Server pulls in xray/relay machinery we don't need
+// here.
+func mwHarness(t *testing.T, cfg *config.Config) (*echo.Echo, *authenticator) {
+	t.Helper()
+	e := echo.New()
+	auth := newAuthenticator(cfg)
+	e.Use(auth.authMiddleware())
+	e.GET("/api/v1/config/", func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+	e.GET("/api/v1/auth/info", func(c echo.Context) error {
+		// Mirror Server.AuthInfo's contract.
+		ok, _, _ := auth.checkRequest(c.Request())
+		return c.JSON(http.StatusOK, map[string]bool{
+			"auth_required": auth.authRequired(),
+			"authenticated": ok,
+		})
+	})
+	return e, auth
+}
+
+func TestAuthDisabled_PassesThrough(t *testing.T) {
+	e, _ := mwHarness(t, &config.Config{})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/config/", nil)
+	rr := httptest.NewRecorder()
+	e.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("auth disabled: expected 200, got %d body=%q", rr.Code, rr.Body.String())
+	}
+}
+
+func TestAuthRequired_RejectsAnonymous(t *testing.T) {
+	e, _ := mwHarness(t, &config.Config{DashboardPass: "letmein"})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/config/", nil)
+	rr := httptest.NewRecorder()
+	e.ServeHTTP(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("anonymous: expected 401, got %d", rr.Code)
+	}
+}
+
+func TestAuthRequired_AcceptsValidSession(t *testing.T) {
+	e, auth := mwHarness(t, &config.Config{DashboardPass: "letmein"})
+	sid, _, err := auth.sessions.issue()
+	if err != nil {
+		t.Fatalf("issue session: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/config/", nil)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sid})
+	rr := httptest.NewRecorder()
+	e.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("valid session: expected 200, got %d body=%q", rr.Code, rr.Body.String())
+	}
+}
+
+func TestAuthRequired_RejectsUnknownSid(t *testing.T) {
+	e, _ := mwHarness(t, &config.Config{DashboardPass: "letmein"})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/config/", nil)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: "not-a-real-sid"})
+	rr := httptest.NewRecorder()
+	e.ServeHTTP(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("unknown sid: expected 401, got %d", rr.Code)
+	}
+}
+
+func TestAuthRequired_AcceptsBearer(t *testing.T) {
+	e, _ := mwHarness(t, &config.Config{ApiToken: "secret-token"})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/config/", nil)
+	req.Header.Set("Authorization", "Bearer secret-token")
+	rr := httptest.NewRecorder()
+	e.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("bearer: expected 200, got %d", rr.Code)
+	}
+}
+
+func TestAuthRequired_AcceptsXEhcoToken(t *testing.T) {
+	e, _ := mwHarness(t, &config.Config{ApiToken: "secret-token"})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/config/", nil)
+	req.Header.Set("X-Ehco-Token", "secret-token")
+	rr := httptest.NewRecorder()
+	e.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("x-ehco-token: expected 200, got %d", rr.Code)
+	}
+}
+
+func TestAuthRequired_RejectsWrongBearer(t *testing.T) {
+	e, _ := mwHarness(t, &config.Config{ApiToken: "secret-token"})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/config/", nil)
+	req.Header.Set("Authorization", "Bearer something-else")
+	rr := httptest.NewRecorder()
+	e.ServeHTTP(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("wrong bearer: expected 401, got %d", rr.Code)
+	}
+}
+
+func TestAuthInfo_PublicEvenWithAuthRequired(t *testing.T) {
+	e, _ := mwHarness(t, &config.Config{DashboardPass: "letmein"})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/info", nil)
+	rr := httptest.NewRecorder()
+	e.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("auth/info should be public, got %d", rr.Code)
+	}
+	if !strings.Contains(rr.Body.String(), `"auth_required":true`) {
+		t.Fatalf("auth/info body missing auth_required=true: %q", rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), `"authenticated":false`) {
+		t.Fatalf("auth/info body missing authenticated=false: %q", rr.Body.String())
+	}
+}
+
+func TestSessionStore_Sliding(t *testing.T) {
+	s := newSessionStore()
+	sid, exp1, err := s.issue()
+	if err != nil {
+		t.Fatalf("issue: %v", err)
+	}
+	ok, exp2 := s.validate(sid)
+	if !ok {
+		t.Fatalf("validate(fresh): expected ok")
+	}
+	// Sliding refresh should push expiry forward (or leave equal).
+	if exp2.Before(exp1) {
+		t.Fatalf("sliding refresh moved expiry backwards: %v < %v", exp2, exp1)
+	}
+}
+
+func TestSessionStore_Revoke(t *testing.T) {
+	s := newSessionStore()
+	sid, _, _ := s.issue()
+	s.revoke(sid)
+	if ok, _ := s.validate(sid); ok {
+		t.Fatalf("revoked sid should not validate")
+	}
+}
+
+func TestLegacyConfigFolding(t *testing.T) {
+	cfg := &config.Config{
+		WebHost:     "127.0.0.1",
+		WebPort:     9999,
+		WebToken:    "legacy-token",
+		WebAuthPass: "legacy-pass",
+	}
+	if err := cfg.Adjust(); err != nil {
+		t.Fatalf("adjust: %v", err)
+	}
+	if cfg.DashboardPass != "legacy-pass" {
+		t.Fatalf("WebAuthPass should fold to DashboardPass, got %q", cfg.DashboardPass)
+	}
+	if cfg.ApiToken != "legacy-token" {
+		t.Fatalf("WebToken should fold to ApiToken, got %q", cfg.ApiToken)
+	}
+}

--- a/internal/web/auth_test.go
+++ b/internal/web/auth_test.go
@@ -154,20 +154,3 @@ func TestSessionStore_Revoke(t *testing.T) {
 	}
 }
 
-func TestLegacyConfigFolding(t *testing.T) {
-	cfg := &config.Config{
-		WebHost:     "127.0.0.1",
-		WebPort:     9999,
-		WebToken:    "legacy-token",
-		WebAuthPass: "legacy-pass",
-	}
-	if err := cfg.Adjust(); err != nil {
-		t.Fatalf("adjust: %v", err)
-	}
-	if cfg.DashboardPass != "legacy-pass" {
-		t.Fatalf("WebAuthPass should fold to DashboardPass, got %q", cfg.DashboardPass)
-	}
-	if cfg.ApiToken != "legacy-token" {
-		t.Fatalf("WebToken should fold to ApiToken, got %q", cfg.ApiToken)
-	}
-}

--- a/internal/web/handler_api.go
+++ b/internal/web/handler_api.go
@@ -95,13 +95,18 @@ func (s *Server) GetRuleMetrics(c echo.Context) error {
 	return c.JSON(http.StatusOK, metrics)
 }
 
-// AuthInfo reports which auth schemes the server is enforcing so the
-// SPA can render the right login form before any credentials exist.
-// Public — must remain reachable without auth.
+// AuthInfo reports whether the server requires login and whether the
+// current request already carries a valid session/bearer. The SPA boots
+// off this — if auth_required is false it skips LoginGate entirely; if
+// authenticated is true on first hit (e.g. cookie still valid) it goes
+// straight to the dashboard.
+//
+// Public — must remain reachable without auth so the SPA can probe.
 func (s *Server) AuthInfo(c echo.Context) error {
+	authenticated, _, _ := s.auth.checkRequest(c.Request())
 	return c.JSON(http.StatusOK, map[string]bool{
-		"token": s.cfg.WebToken != "",
-		"basic": s.cfg.WebAuthUser != "" && s.cfg.WebAuthPass != "",
+		"auth_required": s.auth.authRequired(),
+		"authenticated": authenticated,
 	})
 }
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1,14 +1,12 @@
 package web
 
 import (
-	"crypto/subtle"
 	"fmt"
 	"net"
 	"net/http"
 	_ "net/http/pprof"
 
 	"github.com/labstack/echo/v4"
-	"github.com/labstack/echo/v4/middleware"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.uber.org/zap"
 
@@ -31,6 +29,7 @@ type Server struct {
 	addr string
 	l    *zap.SugaredLogger
 	cfg  *config.Config
+	auth *authenticator
 
 	connMgr cmgr.Cmgr
 }
@@ -48,9 +47,8 @@ func NewServer(
 	l := zap.S().Named("web")
 
 	e := NewEchoServer()
-	if err := setupMiddleware(e, cfg, l); err != nil {
-		return nil, fmt.Errorf("failed to setup middleware: %w", err)
-	}
+	auth := newAuthenticator(cfg)
+	setupMiddleware(e, auth)
 
 	if err := setupMetrics(cfg); err != nil {
 		return nil, fmt.Errorf("failed to setup metrics: %w", err)
@@ -63,6 +61,7 @@ func NewServer(
 		e:       e,
 		l:       l,
 		cfg:     cfg,
+		auth:    auth,
 		connMgr: connMgr,
 		addr:    net.JoinHostPort(cfg.WebHost, fmt.Sprintf("%d", cfg.WebPort)),
 	}
@@ -79,58 +78,11 @@ func validateConfig(cfg *config.Config) error {
 	return nil
 }
 
-func setupMiddleware(e *echo.Echo, cfg *config.Config, _ *zap.SugaredLogger) error {
+func setupMiddleware(e *echo.Echo, auth *authenticator) {
 	e.Use(NginxLogMiddleware(zap.S().Named("web")))
-
-	skipPublic := func(c echo.Context) bool {
-		// SPA shell + its content-hashed assets must load without a token,
-		// otherwise the user can't reach the login modal to enter one.
-		// API/metrics/ws/pprof keep their auth.
-		return isPublicPath(c.Request().URL.Path)
-	}
-
-	if cfg.WebToken != "" {
-		e.Use(middleware.KeyAuthWithConfig(middleware.KeyAuthConfig{
-			Skipper:   skipPublic,
-			KeyLookup: "query:token",
-			Validator: func(key string, _ echo.Context) (bool, error) {
-				return key == cfg.WebToken, nil
-			},
-			// Default behaviour returns 400 when the key is missing entirely;
-			// flatten to 401 so the SPA can treat "needs auth" uniformly
-			// regardless of whether the user submitted a wrong token or none.
-			ErrorHandler: func(err error, _ echo.Context) error {
-				return echo.NewHTTPError(http.StatusUnauthorized, err.Error())
-			},
-		}))
-	}
-
-	if cfg.WebAuthUser != "" && cfg.WebAuthPass != "" {
-		// Custom BasicAuth middleware. Echo's middleware.BasicAuthWithConfig
-		// emits a `WWW-Authenticate: Basic` header on 401, which forces the
-		// browser's native auth dialog. That dialog can't be triggered or
-		// dismissed from the SPA, so we'd have no way to render our own
-		// LoginGate or to sign out (the browser would auto-resend cached
-		// credentials on every reload). Instead we read the header
-		// ourselves, return a plain 401 on failure, and let the SPA own
-		// the login UX end-to-end.
-		e.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
-			return func(c echo.Context) error {
-				if skipPublic(c) {
-					return next(c)
-				}
-				user, pass, ok := c.Request().BasicAuth()
-				if !ok ||
-					subtle.ConstantTimeCompare([]byte(user), []byte(cfg.WebAuthUser)) != 1 ||
-					subtle.ConstantTimeCompare([]byte(pass), []byte(cfg.WebAuthPass)) != 1 {
-					return echo.NewHTTPError(http.StatusUnauthorized, "invalid credentials")
-				}
-				return next(c)
-			}
-		})
-	}
-
-	return nil
+	// Single auth middleware: cookie-session for browsers, bearer-header
+	// for machine clients. No more dual gate, no more query-string token.
+	e.Use(auth.authMiddleware())
 }
 
 func setupMetrics(cfg *config.Config) error {
@@ -151,6 +103,8 @@ func setupRoutes(s *Server) {
 
 	api := e.Group(apiPrefix)
 	api.GET("/auth/info", s.AuthInfo)
+	api.POST("/auth/login", s.HandleLogin)
+	api.POST("/auth/logout", s.HandleLogout)
 	api.GET("/config/", s.CurrentConfig)
 	api.POST("/config/reload/", s.HandleReload)
 	api.GET("/health_check/", s.HandleHealthCheck)

--- a/internal/web/webui/src/api/client.ts
+++ b/internal/web/webui/src/api/client.ts
@@ -1,5 +1,3 @@
-import { creds } from "../store/auth";
-
 export class ApiError extends Error {
   status: number;
   constructor(status: number, msg: string) {
@@ -8,28 +6,15 @@ export class ApiError extends Error {
   }
 }
 
-function withAuth(path: string): { url: string; headers: Record<string, string> } {
-  const c = creds();
-  let url = path;
-  if (c.token) {
-    const u = new URL(path, window.location.origin);
-    u.searchParams.set("token", c.token);
-    url = u.pathname + u.search;
-  }
-  const headers: Record<string, string> = {};
-  if (c.user || c.pass) {
-    headers["Authorization"] = "Basic " + btoa(`${c.user}:${c.pass}`);
-  }
-  return { url, headers };
-}
-
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
-  const { url, headers } = withAuth(path);
-  const res = await fetch(url, {
+  // credentials: same-origin lets the cookie ride. No headers, no
+  // ?token= rewriting — auth is owned by the browser and the server
+  // session store now.
+  const res = await fetch(path, {
     ...init,
+    credentials: "same-origin",
     headers: {
       Accept: "application/json",
-      ...headers,
       ...(init?.headers ?? {}),
     },
   });
@@ -96,8 +81,8 @@ export const api = {
 };
 
 export function wsURL(path: string): string {
+  // WS upgrades carry the session cookie automatically — no query
+  // params, no auth headers (which JS can't set on WS upgrade anyway).
   const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
-  const c = creds();
-  const q = c.token ? `?token=${encodeURIComponent(c.token)}` : "";
-  return `${proto}//${window.location.host}${path}${q}`;
+  return `${proto}//${window.location.host}${path}`;
 }

--- a/internal/web/webui/src/api/types.ts
+++ b/internal/web/webui/src/api/types.ts
@@ -82,7 +82,12 @@ export interface XrayConfig {
 export interface EhcoConfig {
   web_port?: number;
   web_host?: string;
-  web_token?: string;
+  // Server-side dashboard / machine credentials. Sent down with the
+  // config response; the SPA never displays them, but the index
+  // signature catch-all needs them named so consumers don't
+  // accidentally treat them as ordinary settings.
+  dashboard_pass?: string;
+  api_token?: string;
   enable_ping?: boolean;
   log_level?: string;
   reload_interval?: number;

--- a/internal/web/webui/src/components/Layout.tsx
+++ b/internal/web/webui/src/components/Layout.tsx
@@ -17,7 +17,7 @@ import { theme, toggleTheme } from "../store/theme";
 import { authInfo, signOut } from "../store/auth";
 import Logo from "../ui/Logo";
 
-const authConfigured = () => authInfo().token || authInfo().basic;
+const authConfigured = () => authInfo().auth_required;
 
 interface NavItem {
   href: string;

--- a/internal/web/webui/src/components/LoginGate.tsx
+++ b/internal/web/webui/src/components/LoginGate.tsx
@@ -1,33 +1,20 @@
 import { createSignal, Show } from "solid-js";
 import { KeyRound } from "lucide-solid";
-import { authInfo, creds, signIn } from "../store/auth";
+import { signIn } from "../store/auth";
 import Button from "../ui/Button";
 import { Input } from "../ui/Input";
 import Logo from "../ui/Logo";
 
 export default function LoginGate() {
-  const c0 = creds();
-  const [token, setToken] = createSignal(c0.token);
-  const [user, setUser] = createSignal(c0.user);
-  const [pass, setPass] = createSignal(c0.pass);
+  const [pass, setPass] = createSignal("");
   const [busy, setBusy] = createSignal(false);
   const [err, setErr] = createSignal("");
-
-  // If the server doesn't advertise either scheme (e.g. /auth/info
-  // hadn't returned yet, or no auth is configured at all), still let
-  // the user submit something — at worst they'll see a clear error.
-  const showToken = () => authInfo().token || (!authInfo().token && !authInfo().basic);
-  const showBasic = () => authInfo().basic;
 
   const submit = async (e: Event) => {
     e.preventDefault();
     setBusy(true);
     setErr("");
-    const failure = await signIn({
-      token: showToken() ? token() : "",
-      user: showBasic() ? user() : "",
-      pass: showBasic() ? pass() : "",
-    });
+    const failure = await signIn(pass());
     if (failure) setErr(failure);
     setBusy(false);
   };
@@ -42,59 +29,22 @@ export default function LoginGate() {
           <Logo size={40} />
           <div>
             <h1 class="text-base font-semibold leading-none">ehco admin</h1>
-            <p class="mt-1 text-xs text-zinc-500">Authenticate to continue</p>
+            <p class="mt-1 text-xs text-zinc-500">Sign in to continue</p>
           </div>
         </div>
 
-        <Show when={showBasic()}>
-          <label class="mb-1 block text-xs font-medium text-zinc-600 dark:text-zinc-400">
-            Username
-          </label>
-          <Input
-            mono
-            autofocus
-            autocomplete="username"
-            placeholder="web_auth_user"
-            value={user()}
-            onInput={(e) => setUser(e.currentTarget.value)}
-          />
-          <label class="mb-1 mt-3 block text-xs font-medium text-zinc-600 dark:text-zinc-400">
-            Password
-          </label>
-          <Input
-            type="password"
-            mono
-            autocomplete="current-password"
-            placeholder="web_auth_pass"
-            value={pass()}
-            onInput={(e) => setPass(e.currentTarget.value)}
-          />
-        </Show>
-
-        <Show when={showToken()}>
-          <label
-            class={
-              "mb-1 block text-xs font-medium text-zinc-600 dark:text-zinc-400 " +
-              (showBasic() ? "mt-3" : "")
-            }
-          >
-            Access token
-          </label>
-          <Input
-            type="password"
-            mono
-            autofocus={!showBasic()}
-            autocomplete="off"
-            placeholder="web_token"
-            value={token()}
-            onInput={(e) => setToken(e.currentTarget.value)}
-          />
-          <Show when={!showBasic()}>
-            <p class="mt-1.5 text-xs text-zinc-500">
-              Leave empty if your ehco instance has no token gate.
-            </p>
-          </Show>
-        </Show>
+        <label class="mb-1 block text-xs font-medium text-zinc-600 dark:text-zinc-400">
+          Dashboard password
+        </label>
+        <Input
+          type="password"
+          mono
+          autofocus
+          autocomplete="current-password"
+          placeholder="dashboard_pass"
+          value={pass()}
+          onInput={(e) => setPass(e.currentTarget.value)}
+        />
 
         <Show when={err()}>
           <div class="mt-3 rounded-md border border-rose-200 bg-rose-50 p-2 text-xs text-rose-700 dark:border-rose-900/50 dark:bg-rose-950/40 dark:text-rose-400">

--- a/internal/web/webui/src/pages/Settings.tsx
+++ b/internal/web/webui/src/pages/Settings.tsx
@@ -67,13 +67,7 @@ export default function Settings() {
                 ],
                 [
                   "auth",
-                  authInfo().basic && authInfo().token
-                    ? "basic + token"
-                    : authInfo().basic
-                      ? "basic"
-                      : authInfo().token
-                        ? "token"
-                        : "none",
+                  authInfo().auth_required ? "session (cookie / bearer)" : "none",
                 ],
               ]}
             />
@@ -155,19 +149,12 @@ export default function Settings() {
           <div class="mt-3 inline-flex flex-wrap items-center gap-1 text-xs text-zinc-500">
             <Plug size={12} />
             <Show
-              when={authInfo().token || authInfo().basic}
+              when={authInfo().auth_required}
               fallback={<span>No auth configured — all endpoints are open.</span>}
             >
               <span>
-                Requires{" "}
-                <Show when={authInfo().token}>
-                  <code class="font-mono">?token=</code>
-                </Show>
-                <Show when={authInfo().token && authInfo().basic}> + </Show>
-                <Show when={authInfo().basic}>
-                  <code class="font-mono">Authorization: Basic</code>
-                </Show>
-                .
+                Browsers authenticate via the session cookie set at login;
+                machine clients send <code class="font-mono">Authorization: Bearer &lt;api_token&gt;</code>.
               </span>
             </Show>
           </div>

--- a/internal/web/webui/src/store/auth.ts
+++ b/internal/web/webui/src/store/auth.ts
@@ -1,128 +1,87 @@
 import { createSignal } from "solid-js";
-import { api, ApiError } from "../api/client";
-
-const STORAGE = {
-  token: "ehco.token",
-  user: "ehco.user",
-  pass: "ehco.pass",
-};
 
 export type AuthState = "checking" | "needed" | "ok";
 
-export interface Credentials {
-  token: string;
-  user: string;
-  pass: string;
-}
-
 export interface AuthInfo {
-  /** Server requires `?token=…` on every request. */
-  token: boolean;
-  /** Server requires HTTP Basic Auth on every request. */
-  basic: boolean;
+  /** Server has a dashboard password configured. When false the SPA
+   *  loads straight into the dashboard with no LoginGate. */
+  auth_required: boolean;
+  /** Whether the request that fetched /auth/info already carried a
+   *  valid session cookie or bearer token. */
+  authenticated: boolean;
 }
 
-const readInitial = (): Credentials => {
-  const out: Credentials = { token: "", user: "", pass: "" };
-  try {
-    const url = new URL(window.location.href);
-    const fromUrl = url.searchParams.get("token");
-    if (fromUrl) {
-      sessionStorage.setItem(STORAGE.token, fromUrl);
-      url.searchParams.delete("token");
-      window.history.replaceState({}, "", url.toString());
-      out.token = fromUrl;
-    } else {
-      out.token = sessionStorage.getItem(STORAGE.token) ?? "";
-    }
-    out.user = sessionStorage.getItem(STORAGE.user) ?? "";
-    out.pass = sessionStorage.getItem(STORAGE.pass) ?? "";
-  } catch {
-    /* sessionStorage unavailable — leave creds blank */
-  }
-  return out;
-};
-
-const persist = (c: Credentials) => {
-  try {
-    if (c.token) sessionStorage.setItem(STORAGE.token, c.token);
-    else sessionStorage.removeItem(STORAGE.token);
-    if (c.user) sessionStorage.setItem(STORAGE.user, c.user);
-    else sessionStorage.removeItem(STORAGE.user);
-    if (c.pass) sessionStorage.setItem(STORAGE.pass, c.pass);
-    else sessionStorage.removeItem(STORAGE.pass);
-  } catch {
-    /* ignore */
-  }
-};
-
-const [creds, setCredsSig] = createSignal<Credentials>(readInitial());
 const [authState, setAuthState] = createSignal<AuthState>("checking");
 const [authInfo, setAuthInfo] = createSignal<AuthInfo>({
-  token: false,
-  basic: false,
+  auth_required: false,
+  authenticated: false,
 });
 
-export { creds, authState, authInfo };
+export { authState, authInfo };
 
 const fetchAuthInfo = async (): Promise<AuthInfo> => {
   try {
     const res = await fetch("/api/v1/auth/info", {
       headers: { Accept: "application/json" },
+      credentials: "same-origin",
     });
-    if (!res.ok) return { token: false, basic: false };
+    if (!res.ok) return { auth_required: false, authenticated: false };
     return (await res.json()) as AuthInfo;
   } catch {
-    return { token: false, basic: false };
+    return { auth_required: false, authenticated: false };
   }
 };
 
 /**
- * Boot probe. Fetches the server's auth requirements and verifies that
- * the credentials we already have (URL/sessionStorage) actually work.
- * Always lands in either "ok" or "needed" so the UI never sticks.
+ * Boot probe. Hits /auth/info, which both reports whether auth is
+ * needed AND whether the current cookie still authenticates. Always
+ * lands in "ok" or "needed" so the UI never sticks on "checking".
  */
 export async function probeAuth(): Promise<void> {
   setAuthState("checking");
-  setAuthInfo(await fetchAuthInfo());
-  try {
-    await api.config();
+  const info = await fetchAuthInfo();
+  setAuthInfo(info);
+  if (!info.auth_required || info.authenticated) {
     setAuthState("ok");
-  } catch (e) {
-    if (e instanceof ApiError && (e.status === 401 || e.status === 403)) {
-      // Wipe stale creds so the LoginGate starts clean.
-      const empty: Credentials = { token: "", user: "", pass: "" };
-      persist(empty);
-      setCredsSig(empty);
-    }
+  } else {
     setAuthState("needed");
   }
 }
 
-export async function signIn(input: Partial<Credentials>): Promise<string | null> {
-  const next: Credentials = {
-    token: (input.token ?? "").trim(),
-    user: (input.user ?? "").trim(),
-    pass: input.pass ?? "",
-  };
-  persist(next);
-  setCredsSig(next);
+export async function signIn(password: string): Promise<string | null> {
   try {
-    await api.config();
+    const res = await fetch("/api/v1/auth/login", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      credentials: "same-origin",
+      body: JSON.stringify({ password }),
+    });
+    if (res.status === 401) {
+      return "Wrong password.";
+    }
+    if (!res.ok) {
+      return `HTTP ${res.status}: ${(await res.text().catch(() => "")) || res.statusText}`;
+    }
+    setAuthInfo({ ...authInfo(), authenticated: true });
     setAuthState("ok");
     return null;
   } catch (e) {
-    if (e instanceof ApiError && (e.status === 401 || e.status === 403)) {
-      return "Credentials rejected. Check ehco's web_token / web_auth_user / web_auth_pass.";
-    }
-    if (e instanceof ApiError) return `HTTP ${e.status}: ${e.message}`;
     return String(e);
   }
 }
 
-export function signOut() {
-  const empty: Credentials = { token: "", user: "", pass: "" };
-  persist(empty);
-  setCredsSig(empty);
+export async function signOut(): Promise<void> {
+  try {
+    await fetch("/api/v1/auth/logout", {
+      method: "POST",
+      credentials: "same-origin",
+    });
+  } catch {
+    /* server may already have cleared the session — fall through */
+  }
+  setAuthInfo({ ...authInfo(), authenticated: false });
   setAuthState("needed");
 }

--- a/internal/web/webui_embed.go
+++ b/internal/web/webui_embed.go
@@ -89,14 +89,19 @@ func assetHandler() echo.HandlerFunc {
 }
 
 // isPublicPath identifies routes that should bypass the auth middleware
-// so the SPA shell + its public assets can load without a token. API,
-// metrics, ws, and pprof remain protected.
+// so the SPA shell + its public assets and the login flow can load
+// without a session. Metrics, config, WS, and pprof remain protected.
 func isPublicPath(path string) bool {
 	switch path {
 	case "/", "/index.html", "/favicon.ico", "/favicon.svg", "/robots.txt":
 		return true
 	case "/api/v1/auth/info":
-		// SPA queries this before login to know which credentials to ask for.
+		// SPA queries this before login to know whether auth is required.
+		return true
+	case "/api/v1/auth/login", "/api/v1/auth/logout":
+		// Login obviously needs to be reachable without a session;
+		// logout is idempotent and safe to expose unauthenticated so
+		// the SPA can clean up without a round-trip dance.
 		return true
 	}
 	return strings.HasPrefix(path, "/assets/")

--- a/pkg/metric_reader/reader.go
+++ b/pkg/metric_reader/reader.go
@@ -20,6 +20,7 @@ type Reader interface {
 
 type readerImpl struct {
 	metricsURL string
+	apiToken   string // optional bearer token; empty when web auth disabled
 	httpClient *http.Client
 
 	lastMetrics     *NodeMetrics
@@ -27,11 +28,12 @@ type readerImpl struct {
 	l               *zap.SugaredLogger
 }
 
-func NewReader(metricsURL string) *readerImpl {
+func NewReader(metricsURL, apiToken string) *readerImpl {
 	c := &http.Client{Timeout: 30 * time.Second}
 	return &readerImpl{
 		httpClient: c,
 		metricsURL: metricsURL,
+		apiToken:   apiToken,
 		l:          zap.S().Named("metric_reader"),
 	}
 }
@@ -60,6 +62,9 @@ func (r *readerImpl) fetchMetrics(ctx context.Context) (map[string]*dto.MetricFa
 	req, err := http.NewRequestWithContext(ctx, "GET", r.metricsURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	if r.apiToken != "" {
+		req.Header.Set("Authorization", "Bearer "+r.apiToken)
 	}
 
 	resp, err := r.httpClient.Do(req)

--- a/pkg/xray/bandwidth_recorder.go
+++ b/pkg/xray/bandwidth_recorder.go
@@ -25,18 +25,27 @@ type bandwidthRecorder struct {
 
 	httpClient *http.Client
 	metricsURL string
+	apiToken   string // optional bearer token; empty when web auth disabled
 }
 
-func NewBandwidthRecorder(metricsURL string) *bandwidthRecorder {
+func NewBandwidthRecorder(metricsURL, apiToken string) *bandwidthRecorder {
 	c := &http.Client{Timeout: 30 * time.Second}
 	return &bandwidthRecorder{
 		httpClient: c,
 		metricsURL: metricsURL,
+		apiToken:   apiToken,
 	}
 }
 
 func (b *bandwidthRecorder) RecordOnce(ctx context.Context) (uploadIncr float64, downloadIncr float64, err error) {
-	response, err := b.httpClient.Get(b.metricsURL)
+	req, err := http.NewRequestWithContext(ctx, "GET", b.metricsURL, nil)
+	if err != nil {
+		return
+	}
+	if b.apiToken != "" {
+		req.Header.Set("Authorization", "Bearer "+b.apiToken)
+	}
+	response, err := b.httpClient.Do(req)
 	if err != nil {
 		return
 	}

--- a/pkg/xray/server.go
+++ b/pkg/xray/server.go
@@ -157,7 +157,7 @@ func (xs *XrayServer) Setup() error {
 		if len(proxyTags) == 0 {
 			return errors.New("can't find proxy tag in config")
 		}
-		xs.up = NewUserPool(xs.cfg.SyncTrafficEndPoint, xs.cfg.GetMetricURL(), proxyTags)
+		xs.up = NewUserPool(xs.cfg.SyncTrafficEndPoint, xs.cfg.GetMetricURL(), xs.cfg.ApiToken, proxyTags)
 		xs.up.SetConnTracker(xs.tracker)
 
 		im, ok := instance.GetFeature(inbound.ManagerType()).(inbound.Manager)

--- a/pkg/xray/user.go
+++ b/pkg/xray/user.go
@@ -194,7 +194,7 @@ type UserPool struct {
 	remoteConfigURL string
 }
 
-func NewUserPool(remoteConfigURL, metricURL string, proxyTags []string) *UserPool {
+func NewUserPool(remoteConfigURL, metricURL, apiToken string, proxyTags []string) *UserPool {
 	up := &UserPool{
 		l:               zap.L().Named("user_pool"),
 		users:           make(map[int]*User),
@@ -202,7 +202,7 @@ func NewUserPool(remoteConfigURL, metricURL string, proxyTags []string) *UserPoo
 		remoteConfigURL: remoteConfigURL,
 	}
 	if metricURL != "" {
-		up.br = NewBandwidthRecorder(metricURL)
+		up.br = NewBandwidthRecorder(metricURL, apiToken)
 	}
 	return up
 }


### PR DESCRIPTION
## Summary

Replace the KeyAuth(`?token=`) + BasicAuth dual middleware with a single auth path:
- **Browser**: cookie session (`ehco_sid`, 7d sliding TTL, `HttpOnly; SameSite=Strict; Secure-if-TLS`) issued by `POST /api/v1/auth/login`.
- **Machine clients**: `Authorization: Bearer <api_token>` or `X-Ehco-Token`.

`Config.WebToken / WebAuthUser / WebAuthPass` and the legacy folding in `Adjust()` are gone — `DashboardPass` and `ApiToken` are the only auth fields. `GetMetricURL()` no longer embeds creds in the URL; the local `metric_reader` and `bandwidth_recorder` set the bearer header. CLI flag `--web_token` becomes `--dashboard_pass` + `--api_token`.

SPA drops `?token=` and `Authorization: Basic` entirely. WS upgrades carry the cookie natively, so `/ws/logs` works under cookie auth without a ticket-store workaround.

Companion PR: [Ehco1996/mizhiwu#…](https://github.com/Ehco1996/mizhiwu) — `refactor/auth-structured-creds`. **Deploy ehco binary first, then mizhiwu**, otherwise nodes still on the old binary become unauthenticated until upgraded (mizhiwu no longer emits the legacy `web_auth_pass / web_token` keys).

## Commits

1. `e90960e` cookie sessions + bearer-header machine auth, drop dual gate
2. `db320d4` webui cookie-based auth, drop `?token=` and Basic header
3. `f714bbb` drop legacy `WebToken / WebAuth*` fields and Adjust folding

## Test plan

- [x] `make lint` clean
- [x] `go test ./internal/web/... ./internal/config/...` — 9 new auth tests pass (cookie issue / validate / revoke, bearer + X-Ehco-Token accept, wrong-bearer reject, anonymous reject, /auth/info public probe)
- [x] Local e2e against a fresh binary:
  - anon `/api/v1/config/` → 401
  - bearer → 200; wrong bearer → 401; X-Ehco-Token → 200
  - login wrong pass → 401; login right pass → 200 with `Set-Cookie: ehco_sid=…`
  - cookie request → 200; logout → cookie cleared, subsequent → 401
  - `/metrics/` gated by bearer
  - `/auth/info` public, reflects auth_required + authenticated
- [x] `make ui` builds clean
- [ ] After merge, deploy fleet and verify dashboard login + WS logs end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)