### PR TITLE
ms: storage health + query latency + maintenance ops in Settings

### DIFF
--- a/internal/cmgr/cmgr.go
+++ b/internal/cmgr/cmgr.go
@@ -2,6 +2,7 @@ package cmgr
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"sort"
@@ -41,7 +42,20 @@ type Cmgr interface {
 	// Metrics related
 	QueryNodeMetrics(ctx context.Context, req *ms.QueryNodeMetricsReq) (*ms.QueryNodeMetricsResp, error)
 	QueryRuleMetrics(ctx context.Context, req *ms.QueryRuleMetricsReq) (*ms.QueryRuleMetricsResp, error)
+
+	// Storage health & maintenance. Each call surfaces the local
+	// SQLite store; on builds without metrics enabled, the underlying
+	// store is nil and these return ErrMetricsDisabled.
+	DBHealth(ctx context.Context) (*ms.DBHealth, error)
+	DBCleanup(ctx context.Context, days int) (*ms.MaintenanceResult, error)
+	DBVacuum(ctx context.Context) (*ms.MaintenanceResult, error)
+	DBTruncate(ctx context.Context, confirm string) (*ms.MaintenanceResult, error)
+	DBResetStats() error
 }
+
+// ErrMetricsDisabled is returned by storage-health methods when the
+// MetricsStore was never opened (no upstream sync URL configured).
+var ErrMetricsDisabled = errors.New("metrics store disabled")
 
 type cmgrImpl struct {
 	lock sync.RWMutex
@@ -229,4 +243,40 @@ func (cm *cmgrImpl) QueryNodeMetrics(ctx context.Context, req *ms.QueryNodeMetri
 
 func (cm *cmgrImpl) QueryRuleMetrics(ctx context.Context, req *ms.QueryRuleMetricsReq) (*ms.QueryRuleMetricsResp, error) {
 	return cm.ms.QueryRuleMetric(ctx, req)
+}
+
+func (cm *cmgrImpl) DBHealth(ctx context.Context) (*ms.DBHealth, error) {
+	if cm.ms == nil {
+		return nil, ErrMetricsDisabled
+	}
+	return cm.ms.Health(ctx)
+}
+
+func (cm *cmgrImpl) DBCleanup(ctx context.Context, days int) (*ms.MaintenanceResult, error) {
+	if cm.ms == nil {
+		return nil, ErrMetricsDisabled
+	}
+	return cm.ms.CleanupOlderThan(ctx, days)
+}
+
+func (cm *cmgrImpl) DBVacuum(ctx context.Context) (*ms.MaintenanceResult, error) {
+	if cm.ms == nil {
+		return nil, ErrMetricsDisabled
+	}
+	return cm.ms.Vacuum(ctx)
+}
+
+func (cm *cmgrImpl) DBTruncate(ctx context.Context, confirm string) (*ms.MaintenanceResult, error) {
+	if cm.ms == nil {
+		return nil, ErrMetricsDisabled
+	}
+	return cm.ms.Truncate(ctx, confirm)
+}
+
+func (cm *cmgrImpl) DBResetStats() error {
+	if cm.ms == nil {
+		return ErrMetricsDisabled
+	}
+	cm.ms.ResetStats()
+	return nil
 }

--- a/internal/cmgr/ms/handler.go
+++ b/internal/cmgr/ms/handler.go
@@ -65,14 +65,23 @@ type QueryRuleMetricsResp struct {
 }
 
 func (ms *MetricsStore) AddNodeMetric(ctx context.Context, m *metric_reader.NodeMetrics) error {
+	defer track(&ms.stats.AddNode)()
 	_, err := ms.db.ExecContext(ctx, `
     INSERT OR REPLACE INTO node_metrics (timestamp, cpu_usage, memory_usage, disk_usage, network_in, network_out)
     VALUES (?, ?, ?, ?, ?, ?)
 `, m.SyncTime.Unix(), m.CpuUsagePercent, m.MemoryUsagePercent, m.DiskUsagePercent, m.NetworkReceiveBytesRate, m.NetworkTransmitBytesRate)
-	return err
+	if err != nil {
+		return err
+	}
+	// INSERT OR REPLACE may collapse duplicates rather than add a row;
+	// the count is best-effort and is reconciled by recountRows on
+	// next Vacuum / Truncate / restart.
+	ms.nodeRows.Add(1)
+	return nil
 }
 
 func (ms *MetricsStore) AddRuleMetric(ctx context.Context, rm *metric_reader.RuleMetrics) error {
+	defer track(&ms.stats.AddRule)()
 	tx, err := ms.db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
@@ -91,6 +100,7 @@ func (ms *MetricsStore) AddRuleMetric(ctx context.Context, rm *metric_reader.Rul
 	}
 	defer stmt.Close() //nolint:errcheck
 
+	var inserted int64
 	for remote, pingMetric := range rm.PingMetrics {
 		_, err := stmt.ExecContext(ctx, rm.SyncTime.Unix(), rm.Label, remote, pingMetric.Latency,
 			rm.TCPConnectionCount[remote], rm.TCPHandShakeDuration[remote], rm.TCPNetworkTransmitBytes[remote],
@@ -98,12 +108,20 @@ func (ms *MetricsStore) AddRuleMetric(ctx context.Context, rm *metric_reader.Rul
 		if err != nil {
 			return err
 		}
+		inserted++
 	}
 
-	return tx.Commit()
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	// Same caveat as AddNodeMetric: REPLACE collapses, count is
+	// best-effort, reconciled on Vacuum / Truncate / restart.
+	ms.ruleRows.Add(inserted)
+	return nil
 }
 
 func (ms *MetricsStore) QueryNodeMetric(ctx context.Context, req *QueryNodeMetricsReq) (*QueryNodeMetricsResp, error) {
+	defer track(&ms.stats.QueryNode)()
 	var (
 		rows *sql.Rows
 		err  error
@@ -149,6 +167,7 @@ func (ms *MetricsStore) QueryNodeMetric(ctx context.Context, req *QueryNodeMetri
 }
 
 func (ms *MetricsStore) QueryRuleMetric(ctx context.Context, req *QueryRuleMetricsReq) (*QueryRuleMetricsResp, error) {
+	defer track(&ms.stats.QueryRule)()
 	// Bucketed mode keeps the last sample per (label, remote) inside each
 	// step-second window. The bytes columns are monotonic counters, so
 	// last-of-bucket preserves the deltas the SPA computes — averaging

--- a/internal/cmgr/ms/health.go
+++ b/internal/cmgr/ms/health.go
@@ -1,0 +1,164 @@
+package ms
+
+import (
+	"context"
+	"errors"
+	"os"
+	"time"
+)
+
+// DBHealth is the storage + latency snapshot the Settings page polls.
+// Sized small on purpose: every field is cheap (atomic load or one
+// PRAGMA), so the handler can re-run on every refresh without a full
+// COUNT(*) scan against the live tables.
+type DBHealth struct {
+	FileBytes       int64                      `json:"db_file_bytes"`
+	PageCount       int64                      `json:"db_page_count"`
+	PageSize        int64                      `json:"db_page_size"`
+	FreelistPages   int64                      `json:"db_freelist_pages"`
+	NodeMetricsRows int64                      `json:"node_metrics_rows"`
+	RuleMetricsRows int64                      `json:"rule_metrics_rows"`
+	LastRuleWriteTs int64                      `json:"last_rule_write_ts"`
+	Stats           map[string]OpStatsSnapshot `json:"stats"`
+}
+
+func (ms *MetricsStore) Health(ctx context.Context) (*DBHealth, error) {
+	h := &DBHealth{
+		NodeMetricsRows: ms.nodeRows.Load(),
+		RuleMetricsRows: ms.ruleRows.Load(),
+		Stats:           ms.stats.Snapshot(),
+	}
+	if fi, err := os.Stat(ms.dbPath); err == nil {
+		h.FileBytes = fi.Size()
+	}
+	if err := ms.db.QueryRowContext(ctx, "PRAGMA page_count").Scan(&h.PageCount); err != nil {
+		return nil, err
+	}
+	if err := ms.db.QueryRowContext(ctx, "PRAGMA page_size").Scan(&h.PageSize); err != nil {
+		return nil, err
+	}
+	if err := ms.db.QueryRowContext(ctx, "PRAGMA freelist_count").Scan(&h.FreelistPages); err != nil {
+		return nil, err
+	}
+	// COALESCE keeps the JSON shape (always int64) even when the table
+	// is empty — caller distinguishes "never written" via the 0 value.
+	if err := ms.db.QueryRowContext(ctx,
+		"SELECT COALESCE(MAX(timestamp), 0) FROM rule_metrics").Scan(&h.LastRuleWriteTs); err != nil {
+		return nil, err
+	}
+	return h, nil
+}
+
+// MaintenanceResult is the common shape returned by every maintenance
+// op. Fields not relevant to a given op are left zero — Vacuum doesn't
+// fill in NodeDeleted, Cleanup doesn't fill in BytesBefore, etc.
+type MaintenanceResult struct {
+	NodeDeleted int64 `json:"node_deleted,omitempty"`
+	RuleDeleted int64 `json:"rule_deleted,omitempty"`
+	BytesBefore int64 `json:"bytes_before,omitempty"`
+	BytesAfter  int64 `json:"bytes_after,omitempty"`
+	DurationMs  int64 `json:"duration_ms"`
+}
+
+// CleanupOlderThan deletes rows older than `days` from both metrics
+// tables. days <= 0 falls back to the historical 30-day default.
+func (ms *MetricsStore) CleanupOlderThan(ctx context.Context, days int) (*MaintenanceResult, error) {
+	defer track(&ms.stats.Cleanup)()
+	if days <= 0 {
+		days = defaultRetentionDays
+	}
+	start := time.Now()
+	cutoff := time.Now().AddDate(0, 0, -days).Unix()
+	nodeDel, ruleDel, err := ms.deleteOlderThan(cutoff)
+	if err != nil {
+		return nil, err
+	}
+	_ = ctx // ctx kept for symmetry; deleteOlderThan uses ms.db directly
+	return &MaintenanceResult{
+		NodeDeleted: nodeDel,
+		RuleDeleted: ruleDel,
+		DurationMs:  time.Since(start).Milliseconds(),
+	}, nil
+}
+
+// Vacuum reclaims free pages, blocking other queries for the duration.
+// Cheap when the db is small (current ~2.5MB → <100ms); when it grows
+// past ~1GB the lock window can stretch into multi-second territory —
+// the SPA documents this in the confirm copy.
+func (ms *MetricsStore) Vacuum(ctx context.Context) (*MaintenanceResult, error) {
+	defer track(&ms.stats.Vacuum)()
+	start := time.Now()
+	before := ms.dbFileSize()
+	if _, err := ms.db.ExecContext(ctx, "VACUUM"); err != nil {
+		return nil, err
+	}
+	after := ms.dbFileSize()
+	if err := ms.recountRows(); err != nil {
+		return nil, err
+	}
+	ms.l.Infof("vacuum: %d -> %d bytes in %s", before, after, time.Since(start))
+	return &MaintenanceResult{
+		BytesBefore: before,
+		BytesAfter:  after,
+		DurationMs:  time.Since(start).Milliseconds(),
+	}, nil
+}
+
+// ErrTruncateNotConfirmed is returned by Truncate when the caller does
+// not pass the exact confirm literal. The handler turns this into a
+// 400 so a missing form value can never wipe live data.
+var ErrTruncateNotConfirmed = errors.New("truncate requires confirm=\"yes I am sure\"")
+
+// truncateConfirm is the literal the API requires. Plain string, not
+// boolean: a defaulted JSON field (`{}` → false) must not pass; only
+// an explicit, typed phrase counts.
+const truncateConfirm = "yes I am sure"
+
+// Truncate empties both metrics tables and reclaims the freelist via
+// VACUUM. The confirm string must match truncateConfirm exactly.
+func (ms *MetricsStore) Truncate(ctx context.Context, confirm string) (*MaintenanceResult, error) {
+	if confirm != truncateConfirm {
+		return nil, ErrTruncateNotConfirmed
+	}
+	defer track(&ms.stats.Truncate)()
+	start := time.Now()
+	before := ms.dbFileSize()
+	nodeBefore := ms.nodeRows.Load()
+	ruleBefore := ms.ruleRows.Load()
+	if _, err := ms.db.ExecContext(ctx, "DELETE FROM node_metrics"); err != nil {
+		return nil, err
+	}
+	if _, err := ms.db.ExecContext(ctx, "DELETE FROM rule_metrics"); err != nil {
+		return nil, err
+	}
+	if _, err := ms.db.ExecContext(ctx, "VACUUM"); err != nil {
+		return nil, err
+	}
+	if err := ms.recountRows(); err != nil {
+		return nil, err
+	}
+	after := ms.dbFileSize()
+	ms.l.Warnf("truncate: deleted node=%d rule=%d, %d -> %d bytes",
+		nodeBefore, ruleBefore, before, after)
+	return &MaintenanceResult{
+		NodeDeleted: nodeBefore,
+		RuleDeleted: ruleBefore,
+		BytesBefore: before,
+		BytesAfter:  after,
+		DurationMs:  time.Since(start).Milliseconds(),
+	}, nil
+}
+
+// ResetStats zeroes every opStats counter. Operator escape hatch when a
+// one-off latency spike (e.g. cold start, paused process) has poisoned
+// the running max and the page is hard to read.
+func (ms *MetricsStore) ResetStats() {
+	ms.stats.Reset()
+}
+
+func (ms *MetricsStore) dbFileSize() int64 {
+	if fi, err := os.Stat(ms.dbPath); err == nil {
+		return fi.Size()
+	}
+	return 0
+}

--- a/internal/cmgr/ms/health_test.go
+++ b/internal/cmgr/ms/health_test.go
@@ -1,0 +1,141 @@
+package ms
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Ehco1996/ehco/pkg/metric_reader"
+)
+
+func newTestStore(t *testing.T) *MetricsStore {
+	t.Helper()
+	ms, err := NewMetricsStore(filepath.Join(t.TempDir(), "metrics.db"))
+	if err != nil {
+		t.Fatalf("NewMetricsStore: %v", err)
+	}
+	t.Cleanup(func() { _ = ms.Close() })
+	return ms
+}
+
+func TestHealth_EmptyStore(t *testing.T) {
+	ms := newTestStore(t)
+	h, err := ms.Health(context.Background())
+	if err != nil {
+		t.Fatalf("Health: %v", err)
+	}
+	if h.NodeMetricsRows != 0 || h.RuleMetricsRows != 0 {
+		t.Fatalf("expected empty store, got node=%d rule=%d", h.NodeMetricsRows, h.RuleMetricsRows)
+	}
+	if h.PageSize == 0 {
+		t.Fatalf("page size should be reported (got 0)")
+	}
+	if _, ok := h.Stats["query_node"]; !ok {
+		t.Fatalf("stats map missing query_node key")
+	}
+}
+
+func TestHealth_TracksWritesAndQueries(t *testing.T) {
+	ms := newTestStore(t)
+	ctx := context.Background()
+
+	now := time.Now()
+	if err := ms.AddNodeMetric(ctx, &metric_reader.NodeMetrics{
+		SyncTime:                 now,
+		CpuUsagePercent:          1,
+		MemoryUsagePercent:       2,
+		DiskUsagePercent:         3,
+		NetworkReceiveBytesRate:  4,
+		NetworkTransmitBytesRate: 5,
+	}); err != nil {
+		t.Fatalf("AddNodeMetric: %v", err)
+	}
+
+	if _, err := ms.QueryNodeMetric(ctx, &QueryNodeMetricsReq{
+		StartTimestamp: 0,
+		EndTimestamp:   now.Unix() + 1,
+		Num:            10,
+	}); err != nil {
+		t.Fatalf("QueryNodeMetric: %v", err)
+	}
+
+	h, err := ms.Health(ctx)
+	if err != nil {
+		t.Fatalf("Health: %v", err)
+	}
+	if h.NodeMetricsRows != 1 {
+		t.Fatalf("expected 1 node row, got %d", h.NodeMetricsRows)
+	}
+	if h.Stats["add_node"].Count != 1 {
+		t.Fatalf("expected add_node count=1, got %d", h.Stats["add_node"].Count)
+	}
+	if h.Stats["query_node"].Count != 1 {
+		t.Fatalf("expected query_node count=1, got %d", h.Stats["query_node"].Count)
+	}
+	// Latency on a temp-dir SQLite should be sub-100ms; this guards
+	// against the recorder accidentally storing zeros for everything.
+	if h.Stats["add_node"].LastMs <= 0 {
+		t.Fatalf("expected non-zero last_ms for add_node, got %v", h.Stats["add_node"].LastMs)
+	}
+}
+
+func TestCleanupOlderThan_RemovesAndReportsCounts(t *testing.T) {
+	ms := newTestStore(t)
+	ctx := context.Background()
+
+	old := time.Now().Add(-90 * 24 * time.Hour)
+	fresh := time.Now()
+	for _, ts := range []time.Time{old, fresh} {
+		if err := ms.AddNodeMetric(ctx, &metric_reader.NodeMetrics{SyncTime: ts}); err != nil {
+			t.Fatalf("AddNodeMetric: %v", err)
+		}
+	}
+
+	res, err := ms.CleanupOlderThan(ctx, 30)
+	if err != nil {
+		t.Fatalf("CleanupOlderThan: %v", err)
+	}
+	if res.NodeDeleted != 1 {
+		t.Fatalf("expected 1 node deletion, got %d", res.NodeDeleted)
+	}
+	h, _ := ms.Health(ctx)
+	if h.NodeMetricsRows != 1 {
+		t.Fatalf("expected 1 row remaining, got %d", h.NodeMetricsRows)
+	}
+}
+
+func TestTruncate_RequiresExactConfirm(t *testing.T) {
+	ms := newTestStore(t)
+	ctx := context.Background()
+	if err := ms.AddNodeMetric(ctx, &metric_reader.NodeMetrics{SyncTime: time.Now()}); err != nil {
+		t.Fatalf("AddNodeMetric: %v", err)
+	}
+
+	for _, bad := range []string{"", "yes", "true", "YES I AM SURE"} {
+		if _, err := ms.Truncate(ctx, bad); err == nil {
+			t.Fatalf("expected Truncate(%q) to fail", bad)
+		}
+	}
+	if _, err := ms.Truncate(ctx, truncateConfirm); err != nil {
+		t.Fatalf("Truncate with valid confirm: %v", err)
+	}
+	h, _ := ms.Health(ctx)
+	if h.NodeMetricsRows != 0 {
+		t.Fatalf("expected empty after truncate, got %d", h.NodeMetricsRows)
+	}
+}
+
+func TestResetStats_ClearsCounters(t *testing.T) {
+	ms := newTestStore(t)
+	ctx := context.Background()
+	_ = ms.AddNodeMetric(ctx, &metric_reader.NodeMetrics{SyncTime: time.Now()})
+	if h, _ := ms.Health(ctx); h.Stats["add_node"].Count != 1 {
+		t.Fatalf("setup: expected add_node count=1")
+	}
+	ms.ResetStats()
+	h, _ := ms.Health(ctx)
+	if h.Stats["add_node"].Count != 0 {
+		t.Fatalf("expected count=0 after reset, got %d", h.Stats["add_node"].Count)
+	}
+}

--- a/internal/cmgr/ms/ms.go
+++ b/internal/cmgr/ms/ms.go
@@ -4,17 +4,35 @@ import (
 	"database/sql"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"time"
 
 	"go.uber.org/zap"
 	_ "modernc.org/sqlite"
 )
 
+// defaultRetentionDays is how far back cleanOldData and the
+// CleanupOlderThan default keep rows. Mirrors the historical 30d window.
+const defaultRetentionDays = 30
+
 type MetricsStore struct {
 	db     *sql.DB
 	dbPath string
 
 	l *zap.SugaredLogger
+
+	// stats is the latency/throughput recorder shared by every public
+	// method on this store. See stats.go.
+	stats Stats
+
+	// nodeRows / ruleRows are best-effort row-count caches kept in
+	// sync with INSERT / DELETE so Health() doesn't need a per-call
+	// SELECT COUNT(*). Refreshed on startup, recomputed after
+	// Cleanup / Truncate / Vacuum where the exact post-state matters.
+	// INSERT OR REPLACE on a duplicate PK can briefly overcount; the
+	// drift is bounded and resets every time Recount() runs.
+	nodeRows atomic.Int64
+	ruleRows atomic.Int64
 }
 
 func NewMetricsStore(dbPath string) (*MetricsStore, error) {
@@ -45,25 +63,59 @@ func NewMetricsStore(dbPath string) (*MetricsStore, error) {
 	if err := ms.cleanOldData(); err != nil {
 		return nil, err
 	}
+	if err := ms.recountRows(); err != nil {
+		return nil, err
+	}
 	return ms, nil
 }
 
+func (ms *MetricsStore) Close() error {
+	return ms.db.Close()
+}
+
 func (ms *MetricsStore) cleanOldData() error {
-	thirtyDaysAgo := time.Now().AddDate(0, 0, -30).Unix()
+	defer track(&ms.stats.Cleanup)()
+	cutoff := time.Now().AddDate(0, 0, -defaultRetentionDays).Unix()
+	_, _, err := ms.deleteOlderThan(cutoff)
+	return err
+}
 
-	// 清理 node_metrics 表
-	_, err := ms.db.Exec("DELETE FROM node_metrics WHERE timestamp < ?", thirtyDaysAgo)
+// deleteOlderThan runs the two-table prune and returns the number of
+// rows removed from each. Centralises the SQL so cleanOldData and the
+// CleanupOlderThan API path stay consistent.
+func (ms *MetricsStore) deleteOlderThan(cutoff int64) (nodeDeleted, ruleDeleted int64, err error) {
+	res, err := ms.db.Exec("DELETE FROM node_metrics WHERE timestamp < ?", cutoff)
 	if err != nil {
+		return 0, 0, err
+	}
+	nodeDeleted, _ = res.RowsAffected()
+
+	res, err = ms.db.Exec("DELETE FROM rule_metrics WHERE timestamp < ?", cutoff)
+	if err != nil {
+		return nodeDeleted, 0, err
+	}
+	ruleDeleted, _ = res.RowsAffected()
+
+	ms.nodeRows.Add(-nodeDeleted)
+	ms.ruleRows.Add(-ruleDeleted)
+	ms.l.Infof("pruned node_metrics=%d rule_metrics=%d (cutoff=%d)", nodeDeleted, ruleDeleted, cutoff)
+	return nodeDeleted, ruleDeleted, nil
+}
+
+// recountRows refreshes the cached row counts from the source of truth.
+// Cheap on startup (db usually small, even at 30d full retention); we
+// also call it after Truncate / Vacuum where the cache may have drifted
+// or been wiped wholesale.
+func (ms *MetricsStore) recountRows() error {
+	var nodeRows, ruleRows int64
+	if err := ms.db.QueryRow("SELECT COUNT(*) FROM node_metrics").Scan(&nodeRows); err != nil {
 		return err
 	}
-
-	// 清理 rule_metrics 表
-	_, err = ms.db.Exec("DELETE FROM rule_metrics WHERE timestamp < ?", thirtyDaysAgo)
-	if err != nil {
+	if err := ms.db.QueryRow("SELECT COUNT(*) FROM rule_metrics").Scan(&ruleRows); err != nil {
 		return err
 	}
-
-	ms.l.Infof("Cleaned data older than 30 days")
+	ms.nodeRows.Store(nodeRows)
+	ms.ruleRows.Store(ruleRows)
 	return nil
 }
 

--- a/internal/cmgr/ms/stats.go
+++ b/internal/cmgr/ms/stats.go
@@ -1,0 +1,118 @@
+package ms
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// opStats accumulates count + total + max + last latency for one named
+// SQL operation. Lifetime-since-process-start semantics; reset via
+// (*Stats).Reset to clear a one-off spike.
+type opStats struct {
+	count   atomic.Int64
+	totalNs atomic.Int64
+	maxNs   atomic.Int64
+	lastNs  atomic.Int64
+}
+
+func (s *opStats) record(d time.Duration) {
+	ns := d.Nanoseconds()
+	s.count.Add(1)
+	s.totalNs.Add(ns)
+	s.lastNs.Store(ns)
+	for {
+		m := s.maxNs.Load()
+		if ns <= m || s.maxNs.CompareAndSwap(m, ns) {
+			return
+		}
+	}
+}
+
+func (s *opStats) reset() {
+	s.count.Store(0)
+	s.totalNs.Store(0)
+	s.maxNs.Store(0)
+	s.lastNs.Store(0)
+}
+
+// OpStatsSnapshot is the serialisable view of one opStats. Durations
+// are reported in milliseconds — the SPA never needs sub-ms precision.
+type OpStatsSnapshot struct {
+	Count  int64   `json:"count"`
+	AvgMs  float64 `json:"avg_ms"`
+	MaxMs  float64 `json:"max_ms"`
+	LastMs float64 `json:"last_ms"`
+}
+
+func (s *opStats) snapshot() OpStatsSnapshot {
+	count := s.count.Load()
+	out := OpStatsSnapshot{
+		Count:  count,
+		MaxMs:  float64(s.maxNs.Load()) / 1e6,
+		LastMs: float64(s.lastNs.Load()) / 1e6,
+	}
+	if count > 0 {
+		out.AvgMs = float64(s.totalNs.Load()) / float64(count) / 1e6
+	}
+	return out
+}
+
+// Stats bundles every tracked op. Add a field here, register it in
+// (*Stats).All, and the dashboard picks it up automatically.
+type Stats struct {
+	AddNode    opStats
+	AddRule    opStats
+	QueryNode  opStats
+	QueryRule  opStats
+	Cleanup    opStats
+	Vacuum     opStats
+	Truncate   opStats
+}
+
+func (s *Stats) all() []namedOp {
+	return []namedOp{
+		{"add_node", &s.AddNode},
+		{"add_rule", &s.AddRule},
+		{"query_node", &s.QueryNode},
+		{"query_rule", &s.QueryRule},
+		{"cleanup", &s.Cleanup},
+		{"vacuum", &s.Vacuum},
+		{"truncate", &s.Truncate},
+	}
+}
+
+type namedOp struct {
+	name string
+	s    *opStats
+}
+
+// Snapshot renders every tracked op into a name-keyed map suitable
+// for direct JSON encoding.
+func (s *Stats) Snapshot() map[string]OpStatsSnapshot {
+	all := s.all()
+	out := make(map[string]OpStatsSnapshot, len(all))
+	for _, n := range all {
+		out[n.name] = n.s.snapshot()
+	}
+	return out
+}
+
+// Reset clears all tracked ops in one call. Used by the
+// "Reset stats" Settings button.
+func (s *Stats) Reset() {
+	for _, n := range s.all() {
+		n.s.reset()
+	}
+}
+
+// track is the canonical instrumentation helper. Idiomatic use:
+//
+//	defer track(&ms.stats.QueryRule)()
+//
+// The returned closure captures the start time at the point of
+// invocation, so the deferred call records (now - start) regardless of
+// how the function unwinds.
+func track(s *opStats) func() {
+	start := time.Now()
+	return func() { s.record(time.Since(start)) }
+}

--- a/internal/web/handler_api.go
+++ b/internal/web/handler_api.go
@@ -2,11 +2,13 @@ package web
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
 	"time"
 
+	"github.com/Ehco1996/ehco/internal/cmgr"
 	"github.com/Ehco1996/ehco/internal/cmgr/ms"
 	"github.com/Ehco1996/ehco/internal/glue"
 	"github.com/labstack/echo/v4"
@@ -177,6 +179,75 @@ func (s *Server) Overview(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, out)
+}
+
+// dbMaintenanceErr maps domain errors from the cmgr/ms layer onto echo
+// HTTP errors. Centralised so every db/* handler treats the same error
+// the same way.
+func dbMaintenanceErr(err error) *echo.HTTPError {
+	switch {
+	case errors.Is(err, cmgr.ErrMetricsDisabled):
+		return echo.NewHTTPError(http.StatusServiceUnavailable, err.Error())
+	case errors.Is(err, ms.ErrTruncateNotConfirmed):
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	default:
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+}
+
+func (s *Server) GetDBHealth(c echo.Context) error {
+	h, err := s.connMgr.DBHealth(c.Request().Context())
+	if err != nil {
+		return dbMaintenanceErr(err)
+	}
+	return c.JSON(http.StatusOK, h)
+}
+
+type dbCleanupReq struct {
+	OlderThanDays int `json:"older_than_days"`
+}
+
+func (s *Server) PostDBCleanup(c echo.Context) error {
+	var req dbCleanupReq
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+	res, err := s.connMgr.DBCleanup(c.Request().Context(), req.OlderThanDays)
+	if err != nil {
+		return dbMaintenanceErr(err)
+	}
+	return c.JSON(http.StatusOK, res)
+}
+
+func (s *Server) PostDBVacuum(c echo.Context) error {
+	res, err := s.connMgr.DBVacuum(c.Request().Context())
+	if err != nil {
+		return dbMaintenanceErr(err)
+	}
+	return c.JSON(http.StatusOK, res)
+}
+
+type dbTruncateReq struct {
+	Confirm string `json:"confirm"`
+}
+
+func (s *Server) PostDBTruncate(c echo.Context) error {
+	var req dbTruncateReq
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+	res, err := s.connMgr.DBTruncate(c.Request().Context(), req.Confirm)
+	if err != nil {
+		return dbMaintenanceErr(err)
+	}
+	return c.JSON(http.StatusOK, res)
+}
+
+func (s *Server) PostDBResetStats(c echo.Context) error {
+	if err := s.connMgr.DBResetStats(); err != nil {
+		return dbMaintenanceErr(err)
+	}
+	return c.NoContent(http.StatusNoContent)
 }
 
 func (s *Server) HandleHealthCheck(c echo.Context) error {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -132,6 +132,16 @@ func setupRoutes(s *Server) {
 	api.POST("/update/apply", s.UpdateApply)
 	api.GET("/update/status", s.UpdateStatus)
 
+	// Local SQLite store: read-side health snapshot + maintenance ops.
+	// All four mutations are auth-gated through the api group's
+	// existing middleware — the /db/truncate confirm-string is a
+	// second line of defence, not a first.
+	api.GET("/db/health", s.GetDBHealth)
+	api.POST("/db/cleanup", s.PostDBCleanup)
+	api.POST("/db/vacuum", s.PostDBVacuum)
+	api.POST("/db/truncate", s.PostDBTruncate)
+	api.POST("/db/reset_stats", s.PostDBResetStats)
+
 	e.GET("/ws/logs", s.handleWebSocketLogs)
 
 	// SPA: assets are served from the embedded dist tree, every other

--- a/internal/web/webui/src/api/client.ts
+++ b/internal/web/webui/src/api/client.ts
@@ -39,6 +39,8 @@ import type {
   UpdateStatus,
   UpdateApplyOptions,
   OverviewResp,
+  DBHealth,
+  DBMaintenanceResult,
 } from "./types";
 
 export const api = {
@@ -96,6 +98,23 @@ export const api = {
       body: JSON.stringify(opts),
     }),
   updateStatus: () => request<UpdateStatus>("/api/v1/update/status"),
+  dbHealth: () => request<DBHealth>("/api/v1/db/health"),
+  dbCleanup: (older_than_days: number) =>
+    request<DBMaintenanceResult>("/api/v1/db/cleanup", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ older_than_days }),
+    }),
+  dbVacuum: () =>
+    request<DBMaintenanceResult>("/api/v1/db/vacuum", { method: "POST" }),
+  dbTruncate: (confirm: string) =>
+    request<DBMaintenanceResult>("/api/v1/db/truncate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ confirm }),
+    }),
+  dbResetStats: () =>
+    request<string>("/api/v1/db/reset_stats", { method: "POST" }),
 };
 
 export function wsURL(path: string): string {

--- a/internal/web/webui/src/api/types.ts
+++ b/internal/web/webui/src/api/types.ts
@@ -161,6 +161,32 @@ export interface UpdateApplyOptions {
   restart: boolean;
 }
 
+export interface OpStatsSnapshot {
+  count: number;
+  avg_ms: number;
+  max_ms: number;
+  last_ms: number;
+}
+
+export interface DBHealth {
+  db_file_bytes: number;
+  db_page_count: number;
+  db_page_size: number;
+  db_freelist_pages: number;
+  node_metrics_rows: number;
+  rule_metrics_rows: number;
+  last_rule_write_ts: number;
+  stats: Record<string, OpStatsSnapshot>;
+}
+
+export interface DBMaintenanceResult {
+  node_deleted?: number;
+  rule_deleted?: number;
+  bytes_before?: number;
+  bytes_after?: number;
+  duration_ms: number;
+}
+
 export interface LogFrame {
   level: string;
   ts?: string;

--- a/internal/web/webui/src/pages/Settings.tsx
+++ b/internal/web/webui/src/pages/Settings.tsx
@@ -1,21 +1,45 @@
-import { createResource, createSignal, Show } from "solid-js";
-import { Palette, RotateCw, Plug, Copy, Check } from "lucide-solid";
+import { createResource, createSignal, For, Show } from "solid-js";
+import {
+  Palette,
+  RotateCw,
+  Plug,
+  Copy,
+  Check,
+  Trash2,
+  HardDrive,
+  AlertTriangle,
+} from "lucide-solid";
 import PageHeader from "../ui/PageHeader";
 import Button from "../ui/Button";
 import { Card, CardHeader } from "../ui/Card";
 import { Pill } from "../ui/Pill";
 import DescList from "../ui/DescList";
 import { api } from "../api/client";
+import type { DBHealth, DBMaintenanceResult } from "../api/types";
 import { authInfo } from "../store/auth";
 import { theme, toggleTheme } from "../store/theme";
+import { bytes } from "../util/format";
 import UpdatesPanel from "./UpdatesPanel";
+
+// truncateConfirm must match the literal in internal/cmgr/ms/health.go.
+// Wire shape, not user copy — the prompt label can change freely, but
+// what we POST cannot.
+const TRUNCATE_CONFIRM = "yes I am sure";
+
+type ToneStatus = {
+  tone: "ok" | "error" | "neutral";
+  text: string;
+} | null;
 
 export default function Settings() {
   const [config] = createResource(() => api.config());
-  const [reloadStatus, setReloadStatus] = createSignal<{
-    tone: "ok" | "error" | "neutral";
-    text: string;
-  } | null>(null);
+  const [health, { refetch: refetchHealth }] = createResource(() =>
+    api.dbHealth(),
+  );
+  const [reloadStatus, setReloadStatus] = createSignal<ToneStatus>(null);
+  const [maintStatus, setMaintStatus] = createSignal<ToneStatus>(null);
+  const [cleanupDays, setCleanupDays] = createSignal(30);
+  const [busyOp, setBusyOp] = createSignal<string | null>(null);
   const [copied, setCopied] = createSignal(false);
 
   const triggerReload = async () => {
@@ -45,6 +69,84 @@ export default function Settings() {
       /* ignore */
     }
   };
+
+  // runMaint funnels every maintenance op through the same loading +
+  // toast-style status pipeline. Keeps the four buttons free of
+  // try/catch boilerplate and ensures the health card always refreshes
+  // on completion.
+  const runMaint = async (
+    op: string,
+    fn: () => Promise<DBMaintenanceResult | string>,
+    fmtOk: (r: DBMaintenanceResult | string) => string,
+  ) => {
+    setBusyOp(op);
+    setMaintStatus({ tone: "neutral", text: `${op}…` });
+    try {
+      const r = await fn();
+      setMaintStatus({ tone: "ok", text: fmtOk(r) });
+      refetchHealth();
+    } catch (e) {
+      setMaintStatus({ tone: "error", text: String(e) });
+    } finally {
+      setBusyOp(null);
+    }
+  };
+
+  const onCleanup = () =>
+    runMaint(
+      "cleanup",
+      () => api.dbCleanup(cleanupDays()),
+      (r) => {
+        const m = r as DBMaintenanceResult;
+        return `pruned node=${m.node_deleted ?? 0} rule=${m.rule_deleted ?? 0} in ${m.duration_ms}ms`;
+      },
+    );
+
+  const onVacuum = () => {
+    if (
+      !confirm(
+        "VACUUM rewrites the db file and locks all queries until done. Cheap on small dbs (~ms), seconds at GB scale. Proceed?",
+      )
+    )
+      return;
+    runMaint(
+      "vacuum",
+      () => api.dbVacuum(),
+      (r) => {
+        const m = r as DBMaintenanceResult;
+        return `${bytes(m.bytes_before)} → ${bytes(m.bytes_after)} in ${m.duration_ms}ms`;
+      },
+    );
+  };
+
+  const onTruncate = () => {
+    const got = prompt(
+      `Wipe ALL local metrics history. This cannot be undone.\n\nType the confirmation phrase exactly:\n  ${TRUNCATE_CONFIRM}`,
+    );
+    if (got == null) return;
+    if (got !== TRUNCATE_CONFIRM) {
+      setMaintStatus({ tone: "error", text: "confirmation phrase mismatch" });
+      return;
+    }
+    runMaint(
+      "truncate",
+      () => api.dbTruncate(got),
+      (r) => {
+        const m = r as DBMaintenanceResult;
+        return `wiped node=${m.node_deleted ?? 0} rule=${m.rule_deleted ?? 0}`;
+      },
+    );
+  };
+
+  const onResetStats = () =>
+    runMaint(
+      "reset_stats",
+      async () => {
+        await api.dbResetStats();
+        return "ok";
+      },
+      () => "stats reset",
+    );
 
   return (
     <>
@@ -129,6 +231,67 @@ export default function Settings() {
           </div>
         </Card>
 
+        <Show when={health()}>
+          <StorageCard h={health()!} />
+          <LatencyCard h={health()!} onReset={onResetStats} busy={busyOp()} />
+
+          <Card class="lg:col-span-2">
+            <CardHeader
+              title="maintenance"
+              subtitle="prune · compact · wipe · reset stats"
+            />
+            <div class="grid gap-3 md:grid-cols-3">
+              <div class="flex items-end gap-2">
+                <label class="flex flex-col text-xs text-zinc-500">
+                  <span class="mb-1">older than (days)</span>
+                  <input
+                    type="number"
+                    min="1"
+                    class="w-24 rounded-md border border-zinc-200 bg-white px-2 py-1 text-sm dark:border-zinc-800 dark:bg-zinc-950"
+                    value={cleanupDays()}
+                    onInput={(e) =>
+                      setCleanupDays(Math.max(1, Number(e.currentTarget.value) || 1))
+                    }
+                  />
+                </label>
+                <Button
+                  leadingIcon={<Trash2 size={13} />}
+                  onClick={onCleanup}
+                  disabled={busyOp() != null}
+                >
+                  Clean
+                </Button>
+              </div>
+              <div class="flex items-end">
+                <Button
+                  leadingIcon={<HardDrive size={13} />}
+                  onClick={onVacuum}
+                  disabled={busyOp() != null}
+                >
+                  VACUUM
+                </Button>
+              </div>
+              <div class="flex items-end">
+                <Button
+                  variant="danger"
+                  leadingIcon={<AlertTriangle size={13} />}
+                  onClick={onTruncate}
+                  disabled={busyOp() != null}
+                >
+                  Truncate all…
+                </Button>
+              </div>
+            </div>
+            <Show when={maintStatus()}>
+              <div class="mt-3">
+                <Pill tone={maintStatus()!.tone} dot>
+                  {maintStatus()!.text}
+                </Pill>
+              </div>
+            </Show>
+          </Card>
+        </Show>
+
         <div class="lg:col-span-2">
           <UpdatesPanel />
         </div>
@@ -145,6 +308,11 @@ export default function Settings() {
             <Endpoint method="GET" path="/api/v1/overview" />
             <Endpoint method="GET" path="/api/v1/node_metrics/" />
             <Endpoint method="GET" path="/api/v1/rule_metrics/" />
+            <Endpoint method="GET" path="/api/v1/db/health" />
+            <Endpoint method="POST" path="/api/v1/db/cleanup" />
+            <Endpoint method="POST" path="/api/v1/db/vacuum" />
+            <Endpoint method="POST" path="/api/v1/db/truncate" />
+            <Endpoint method="POST" path="/api/v1/db/reset_stats" />
             <Endpoint method="GET" path="/api/v1/xray/conns" />
             <Endpoint method="DELETE" path="/api/v1/xray/conns/:id" />
             <Endpoint method="DELETE" path="/api/v1/xray/conns?user=…" />
@@ -167,6 +335,95 @@ export default function Settings() {
         </Card>
       </div>
     </>
+  );
+}
+
+function StorageCard(props: { h: DBHealth }) {
+  const fragPct = () => {
+    const pc = props.h.db_page_count;
+    return pc > 0 ? (props.h.db_freelist_pages / pc) * 100 : 0;
+  };
+  const lastWriteText = () => {
+    if (!props.h.last_rule_write_ts) return "never";
+    const ageSec = Math.max(0, Date.now() / 1000 - props.h.last_rule_write_ts);
+    if (ageSec < 60) return `${Math.round(ageSec)}s ago`;
+    if (ageSec < 3600) return `${Math.round(ageSec / 60)}m ago`;
+    if (ageSec < 86400) return `${Math.round(ageSec / 3600)}h ago`;
+    return `${Math.round(ageSec / 86400)}d ago`;
+  };
+  return (
+    <Card>
+      <CardHeader title="storage" subtitle="local SQLite metrics store" />
+      <DescList
+        items={[
+          ["db file", bytes(props.h.db_file_bytes)],
+          [
+            "pages",
+            `${props.h.db_page_count.toLocaleString()} × ${props.h.db_page_size}B`,
+          ],
+          [
+            "freelist",
+            `${props.h.db_freelist_pages.toLocaleString()} (${fragPct().toFixed(1)}%)${fragPct() > 30 ? " — VACUUM recommended" : ""}`,
+          ],
+          ["node_metrics", `${props.h.node_metrics_rows.toLocaleString()} rows`],
+          [
+            "rule_metrics",
+            `${props.h.rule_metrics_rows.toLocaleString()} rows${props.h.rule_metrics_rows === 0 ? " — no data, check sync pipeline" : ""}`,
+          ],
+          ["last rule write", lastWriteText()],
+        ]}
+      />
+    </Card>
+  );
+}
+
+function LatencyCard(props: {
+  h: DBHealth;
+  onReset: () => void;
+  busy: string | null;
+}) {
+  const rows = () =>
+    Object.entries(props.h.stats).map(([name, s]) => ({ name, ...s }));
+  return (
+    <Card>
+      <CardHeader
+        title="query latency"
+        subtitle="since process start"
+        right={
+          <button
+            class="text-xs text-zinc-500 hover:text-emerald-600 disabled:opacity-50 dark:hover:text-emerald-400"
+            onClick={props.onReset}
+            disabled={props.busy != null}
+          >
+            reset
+          </button>
+        }
+      />
+      <table class="w-full font-mono text-xs">
+        <thead class="text-zinc-500">
+          <tr>
+            <th class="text-left">op</th>
+            <th class="text-right">count</th>
+            <th class="text-right">avg</th>
+            <th class="text-right">max</th>
+            <th class="text-right">last</th>
+          </tr>
+        </thead>
+        <tbody>
+          <For each={rows()}>
+            {(r) => (
+              <tr class="border-t border-zinc-100 dark:border-zinc-900">
+                <td class="py-1">{r.name}</td>
+                <td class="text-right">{r.count.toLocaleString()}</td>
+                <td class="text-right">{r.count ? `${r.avg_ms.toFixed(2)}ms` : "—"}</td>
+                <td class="text-right">{r.count ? `${r.max_ms.toFixed(2)}ms` : "—"}</td>
+                <td class="text-right">{r.count ? `${r.last_ms.toFixed(2)}ms` : "—"}</td>
+              </tr>
+            )}
+          </For>
+        </tbody>
+      </table>
+    </Card>
   );
 }
 

--- a/internal/web/webui/src/pages/Settings.tsx
+++ b/internal/web/webui/src/pages/Settings.tsx
@@ -1,8 +1,6 @@
 import { createResource, createSignal, For, Show } from "solid-js";
 import {
-  Palette,
   RotateCw,
-  Plug,
   Copy,
   Check,
   Trash2,
@@ -17,13 +15,13 @@ import DescList from "../ui/DescList";
 import { api } from "../api/client";
 import type { DBHealth, DBMaintenanceResult } from "../api/types";
 import { authInfo } from "../store/auth";
-import { theme, toggleTheme } from "../store/theme";
 import { bytes } from "../util/format";
+import { copyText } from "../util/clipboard";
 import UpdatesPanel from "./UpdatesPanel";
 
-// truncateConfirm must match the literal in internal/cmgr/ms/health.go.
-// Wire shape, not user copy — the prompt label can change freely, but
-// what we POST cannot.
+// Wire-shape literal — must match the constant in
+// internal/cmgr/ms/health.go. The button label can change freely; what
+// we POST cannot.
 const TRUNCATE_CONFIRM = "yes I am sure";
 
 type ToneStatus = {
@@ -61,19 +59,15 @@ export default function Settings() {
   const copySync = async () => {
     const v = String(config()?.sync_traffic_endpoint ?? "");
     if (!v) return;
-    try {
-      await navigator.clipboard.writeText(v);
+    if (await copyText(v)) {
       setCopied(true);
       setTimeout(() => setCopied(false), 1200);
-    } catch {
-      /* ignore */
     }
   };
 
   // runMaint funnels every maintenance op through the same loading +
-  // toast-style status pipeline. Keeps the four buttons free of
-  // try/catch boilerplate and ensures the health card always refreshes
-  // on completion.
+  // status pipeline so the four buttons stay free of try/catch
+  // boilerplate and the health card always refreshes on completion.
   const runMaint = async (
     op: string,
     fn: () => Promise<DBMaintenanceResult | string>,
@@ -152,13 +146,33 @@ export default function Settings() {
     <>
       <PageHeader
         title="settings"
-        subtitle="local ui preferences · runtime config · admin actions"
+        subtitle="runtime config · storage health · self-update"
       />
 
       <div class="grid gap-3 lg:grid-cols-2">
         <Show when={config()}>
           <Card>
-            <CardHeader title="runtime configuration" subtitle="read-only snapshot" />
+            <CardHeader
+              title="runtime configuration"
+              subtitle="read-only snapshot · re-fetch from upstream"
+              right={
+                <div class="flex items-center gap-2">
+                  {reloadStatus() && (
+                    <Pill tone={reloadStatus()!.tone} dot>
+                      {reloadStatus()!.text}
+                    </Pill>
+                  )}
+                  <Button
+                    size="sm"
+                    variant="primary"
+                    leadingIcon={<RotateCw size={12} />}
+                    onClick={triggerReload}
+                  >
+                    Reload
+                  </Button>
+                </div>
+              }
+            />
             <DescList
               items={[
                 ["log level", String(config()!.log_level ?? "—")],
@@ -196,145 +210,47 @@ export default function Settings() {
             </p>
           </Card>
         </Show>
+      </div>
 
-        <Card>
-          <CardHeader
-            title="reload configuration"
-            subtitle="re-fetch from upstream"
-          />
-          <p class="mb-3 text-sm text-zinc-500">
-            A listener change reloads xray and drops active conns.
-          </p>
-          <div class="flex items-center gap-3">
-            <Button
-              variant="primary"
-              leadingIcon={<RotateCw size={13} />}
-              onClick={triggerReload}
-            >
-              Reload
-            </Button>
-            {reloadStatus() && (
-              <Pill tone={reloadStatus()!.tone} dot>
-                {reloadStatus()!.text}
-              </Pill>
-            )}
-          </div>
-        </Card>
-
-        <Card>
-          <CardHeader title="theme" subtitle="light / dark mode override" />
-          <div class="flex items-center gap-3">
-            <Pill tone="neutral">{theme()}</Pill>
-            <Button leadingIcon={<Palette size={13} />} onClick={toggleTheme}>
-              Toggle
-            </Button>
-          </div>
-        </Card>
-
-        <Show when={health()}>
+      <Show when={health()}>
+        <SectionTitle
+          title="database"
+          subtitle="local SQLite metrics store"
+        />
+        <div class="grid gap-3 lg:grid-cols-2">
           <StorageCard h={health()!} />
           <LatencyCard h={health()!} onReset={onResetStats} busy={busyOp()} />
-
-          <Card class="lg:col-span-2">
-            <CardHeader
-              title="maintenance"
-              subtitle="prune · compact · wipe · reset stats"
-            />
-            <div class="grid gap-3 md:grid-cols-3">
-              <div class="flex items-end gap-2">
-                <label class="flex flex-col text-xs text-zinc-500">
-                  <span class="mb-1">older than (days)</span>
-                  <input
-                    type="number"
-                    min="1"
-                    class="w-24 rounded-md border border-zinc-200 bg-white px-2 py-1 text-sm dark:border-zinc-800 dark:bg-zinc-950"
-                    value={cleanupDays()}
-                    onInput={(e) =>
-                      setCleanupDays(Math.max(1, Number(e.currentTarget.value) || 1))
-                    }
-                  />
-                </label>
-                <Button
-                  leadingIcon={<Trash2 size={13} />}
-                  onClick={onCleanup}
-                  disabled={busyOp() != null}
-                >
-                  Clean
-                </Button>
-              </div>
-              <div class="flex items-end">
-                <Button
-                  leadingIcon={<HardDrive size={13} />}
-                  onClick={onVacuum}
-                  disabled={busyOp() != null}
-                >
-                  VACUUM
-                </Button>
-              </div>
-              <div class="flex items-end">
-                <Button
-                  variant="danger"
-                  leadingIcon={<AlertTriangle size={13} />}
-                  onClick={onTruncate}
-                  disabled={busyOp() != null}
-                >
-                  Truncate all…
-                </Button>
-              </div>
-            </div>
-            <Show when={maintStatus()}>
-              <div class="mt-3">
-                <Pill tone={maintStatus()!.tone} dot>
-                  {maintStatus()!.text}
-                </Pill>
-              </div>
-            </Show>
-          </Card>
-        </Show>
-
-        <div class="lg:col-span-2">
-          <UpdatesPanel />
-        </div>
-
-        <Card class="lg:col-span-2">
-          <CardHeader
-            title="api surface"
-            subtitle="endpoints the ui consumes"
+          <MaintenanceCard
+            cleanupDays={cleanupDays()}
+            setCleanupDays={setCleanupDays}
+            busyOp={busyOp()}
+            status={maintStatus()}
+            onCleanup={onCleanup}
+            onVacuum={onVacuum}
+            onTruncate={onTruncate}
           />
-          <ul class="grid grid-cols-1 gap-y-1 font-mono text-xs text-zinc-600 sm:grid-cols-2 dark:text-zinc-400">
-            <Endpoint method="GET" path="/api/v1/config/" />
-            <Endpoint method="POST" path="/api/v1/config/reload/" />
-            <Endpoint method="GET" path="/api/v1/health_check/" />
-            <Endpoint method="GET" path="/api/v1/overview" />
-            <Endpoint method="GET" path="/api/v1/node_metrics/" />
-            <Endpoint method="GET" path="/api/v1/rule_metrics/" />
-            <Endpoint method="GET" path="/api/v1/db/health" />
-            <Endpoint method="POST" path="/api/v1/db/cleanup" />
-            <Endpoint method="POST" path="/api/v1/db/vacuum" />
-            <Endpoint method="POST" path="/api/v1/db/truncate" />
-            <Endpoint method="POST" path="/api/v1/db/reset_stats" />
-            <Endpoint method="GET" path="/api/v1/xray/conns" />
-            <Endpoint method="DELETE" path="/api/v1/xray/conns/:id" />
-            <Endpoint method="DELETE" path="/api/v1/xray/conns?user=…" />
-            <Endpoint method="GET" path="/api/v1/xray/users" />
-            <Endpoint method="GET" path="/metrics/" />
-            <Endpoint method="WS" path="/ws/logs" />
-          </ul>
-          <div class="mt-3 inline-flex flex-wrap items-center gap-1 text-xs text-zinc-500">
-            <Plug size={12} />
-            <Show
-              when={authInfo().auth_required}
-              fallback={<span>No auth configured — all endpoints are open.</span>}
-            >
-              <span>
-                Browsers authenticate via the session cookie set at login;
-                machine clients send <code class="font-mono">Authorization: Bearer &lt;api_token&gt;</code>.
-              </span>
-            </Show>
-          </div>
-        </Card>
-      </div>
+        </div>
+      </Show>
+
+      <SectionTitle
+        title="updates"
+        subtitle="check for new ehco builds and apply them in place"
+      />
+      <UpdatesPanel />
     </>
+  );
+}
+
+function SectionTitle(props: { title: string; subtitle?: string }) {
+  return (
+    <div class="mb-2 mt-6">
+      <h2 class="text-[12px] font-semibold uppercase tracking-[0.14em] text-zinc-500">
+        {props.title}
+      </h2>
+      <Show when={props.subtitle}>
+        <p class="mt-0.5 text-[11px] text-zinc-500">{props.subtitle}</p>
+      </Show>
+    </div>
   );
 }
 
@@ -353,7 +269,7 @@ function StorageCard(props: { h: DBHealth }) {
   };
   return (
     <Card>
-      <CardHeader title="storage" subtitle="local SQLite metrics store" />
+      <CardHeader title="storage" subtitle="file size · pages · row counts" />
       <DescList
         items={[
           ["db file", bytes(props.h.db_file_bytes)],
@@ -399,25 +315,29 @@ function LatencyCard(props: {
           </button>
         }
       />
-      <table class="w-full font-mono text-xs">
+      <table class="w-full table-fixed font-mono text-xs">
+        <colgroup>
+          <col class="w-[40%]" />
+          <col class="w-[20%]" />
+          <col class="w-[20%]" />
+          <col class="w-[20%]" />
+        </colgroup>
         <thead class="text-zinc-500">
           <tr>
             <th class="text-left">op</th>
             <th class="text-right">count</th>
             <th class="text-right">avg</th>
             <th class="text-right">max</th>
-            <th class="text-right">last</th>
           </tr>
         </thead>
         <tbody>
           <For each={rows()}>
             {(r) => (
               <tr class="border-t border-zinc-100 dark:border-zinc-900">
-                <td class="py-1">{r.name}</td>
+                <td class="py-1 truncate">{r.name}</td>
                 <td class="text-right">{r.count.toLocaleString()}</td>
                 <td class="text-right">{r.count ? `${r.avg_ms.toFixed(2)}ms` : "—"}</td>
                 <td class="text-right">{r.count ? `${r.max_ms.toFixed(2)}ms` : "—"}</td>
-                <td class="text-right">{r.count ? `${r.last_ms.toFixed(2)}ms` : "—"}</td>
               </tr>
             )}
           </For>
@@ -427,20 +347,68 @@ function LatencyCard(props: {
   );
 }
 
-const methodTones: Record<string, "info" | "ok" | "error" | "warn"> = {
-  GET: "info",
-  POST: "ok",
-  DELETE: "error",
-  WS: "warn",
-};
-
-function Endpoint(props: { method: string; path: string }) {
+function MaintenanceCard(props: {
+  cleanupDays: number;
+  setCleanupDays: (n: number) => void;
+  busyOp: string | null;
+  status: ToneStatus;
+  onCleanup: () => void;
+  onVacuum: () => void;
+  onTruncate: () => void;
+}) {
   return (
-    <li class="flex items-center gap-2">
-      <span class="w-12">
-        <Pill tone={methodTones[props.method]}>{props.method}</Pill>
-      </span>
-      <span>{props.path}</span>
-    </li>
+    <Card class="lg:col-span-2">
+      <CardHeader
+        title="maintenance"
+        subtitle="prune · compact · wipe"
+        right={
+          <Show when={props.status}>
+            <Pill tone={props.status!.tone} dot>
+              {props.status!.text}
+            </Pill>
+          </Show>
+        }
+      />
+      <div class="flex flex-wrap items-end gap-3">
+        <label class="flex items-end gap-2">
+          <span class="flex flex-col text-xs text-zinc-500">
+            <span class="mb-1">older than (days)</span>
+            <input
+              type="number"
+              min="1"
+              class="w-20 rounded-md border border-zinc-200 bg-white px-2 py-1 text-sm dark:border-zinc-800 dark:bg-zinc-950"
+              value={props.cleanupDays}
+              onInput={(e) =>
+                props.setCleanupDays(
+                  Math.max(1, Number(e.currentTarget.value) || 1),
+                )
+              }
+            />
+          </span>
+          <Button
+            leadingIcon={<Trash2 size={13} />}
+            onClick={props.onCleanup}
+            disabled={props.busyOp != null}
+          >
+            Clean
+          </Button>
+        </label>
+        <Button
+          leadingIcon={<HardDrive size={13} />}
+          onClick={props.onVacuum}
+          disabled={props.busyOp != null}
+        >
+          VACUUM
+        </Button>
+        <Button
+          variant="danger"
+          leadingIcon={<AlertTriangle size={13} />}
+          onClick={props.onTruncate}
+          disabled={props.busyOp != null}
+        >
+          Truncate all…
+        </Button>
+      </div>
+    </Card>
   );
 }

--- a/internal/web/webui/src/pages/UpdatesPanel.tsx
+++ b/internal/web/webui/src/pages/UpdatesPanel.tsx
@@ -80,14 +80,17 @@ export default function UpdatesPanel() {
     timer = window.setInterval(tick, 1500) as unknown as number;
   };
 
-  // Hydrate any in-flight job on mount so a refresh during update doesn't
-  // lose the indicator.
-  api.updateStatus().then((s) => {
-    if (s.state !== "idle") {
-      setStatus(s);
-      if (s.state !== "done" && s.state !== "failed") startPolling();
-    }
-  }).catch(() => {});
+  // Hydrate any in-flight job on mount so a refresh during update
+  // doesn't lose the indicator.
+  api
+    .updateStatus()
+    .then((s) => {
+      if (s.state !== "idle") {
+        setStatus(s);
+        if (s.state !== "done" && s.state !== "failed") startPolling();
+      }
+    })
+    .catch(() => {});
 
   const runCheck = async () => {
     setChecking(true);
@@ -104,12 +107,19 @@ export default function UpdatesPanel() {
   const applyUpdate = async () => {
     const c = check();
     if (!c) return;
-    if (!confirm(
-      `Update to ${c.latest_version}? This replaces the running binary and restarts ehco. Active connections will drop.`,
-    )) return;
+    if (
+      !confirm(
+        `Update to ${c.latest_version}? This replaces the running binary and restarts ehco. Active connections will drop.`,
+      )
+    )
+      return;
     setApplyErr("");
     try {
-      await api.updateApply({ channel: channel(), force: false, restart: true });
+      await api.updateApply({
+        channel: channel(),
+        force: false,
+        restart: true,
+      });
       setStatus({
         state: "checking",
         channel: channel(),
@@ -125,71 +135,75 @@ export default function UpdatesPanel() {
 
   const inProgress = () => {
     const s = status()?.state;
-    return s === "checking" || s === "downloading" || s === "installing" || s === "restarting";
+    return (
+      s === "checking" ||
+      s === "downloading" ||
+      s === "installing" ||
+      s === "restarting"
+    );
   };
   const isNightly = () => version()?.version.includes("-") ?? false;
   const linuxOnly = () => version()?.go_os === "linux";
 
   return (
     <>
-      <div class="mb-3 flex items-center justify-between">
-        <div>
-          <h2 class="text-[12px] font-semibold uppercase tracking-[0.14em] text-zinc-500">
-            updates
-          </h2>
-          <p class="mt-0.5 text-[11px] text-zinc-500">
-            check for new ehco builds and apply them in place
-          </p>
-        </div>
-        <Pill tone={isNightly() ? "warn" : "info"}>
-          {isNightly() ? "nightly build" : "stable build"}
-        </Pill>
-      </div>
-
       <Card>
-        <CardHeader title="current build" subtitle="reported by this binary" />
+        <CardHeader
+          title="build & self-update"
+          subtitle="github releases · Ehco1996/ehco"
+          right={
+            <div class="flex items-center gap-2">
+              <Show when={version()}>
+                <Pill tone={isNightly() ? "warn" : "info"}>
+                  {isNightly() ? "nightly" : "stable"}
+                </Pill>
+              </Show>
+              <Segmented<Channel>
+                options={[
+                  { value: "auto", label: "Auto" },
+                  { value: "stable", label: "Stable" },
+                  { value: "nightly", label: "Nightly" },
+                ]}
+                value={channel()}
+                onChange={setChannel}
+                size="sm"
+              />
+              <Button
+                size="sm"
+                variant="primary"
+                loading={checking()}
+                leadingIcon={<RefreshCw size={13} />}
+                onClick={runCheck}
+              >
+                Check
+              </Button>
+            </div>
+          }
+        />
+
         <DescList
           items={[
-            ["Version", version()?.version ?? "—"],
-            ["Branch", version()?.git_branch || "—"],
-            ["Commit", (version()?.git_revision ?? "").slice(0, 7) || "—"],
-            ["Built", version()?.build_time || "—"],
-            ["Started", version()?.start_time ? relTime(version()!.start_time) : "—"],
-            ["Platform", version() ? `${version()!.go_os}/${version()!.go_arch}` : "—"],
+            ["version", version()?.version ?? "—"],
+            ["branch", version()?.git_branch || "—"],
+            ["commit", (version()?.git_revision ?? "").slice(0, 7) || "—"],
+            ["built", version()?.build_time || "—"],
+            [
+              "started",
+              version()?.start_time ? relTime(version()!.start_time) : "—",
+            ],
+            [
+              "platform",
+              version() ? `${version()!.go_os}/${version()!.go_arch}` : "—",
+            ],
           ]}
         />
+
         <Show when={version() && !linuxOnly()}>
           <div class="mt-3 rounded-md border border-amber-200 bg-amber-50 p-2 text-xs text-amber-800 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-300">
-            Self-update is only supported on linux. On {version()!.go_os} you'll need to rebuild from source.
+            Self-update is only supported on linux. On {version()!.go_os} you'll
+            need to rebuild from source.
           </div>
         </Show>
-      </Card>
-
-      <Card class="mt-4">
-        <div class="flex flex-wrap items-center gap-3">
-          <CardHeader title="check for updates" subtitle="github releases (Ehco1996/ehco)" />
-          <div class="ml-auto flex items-center gap-2">
-            <Segmented<Channel>
-              options={[
-                { value: "auto", label: "Auto" },
-                { value: "stable", label: "Stable" },
-                { value: "nightly", label: "Nightly" },
-              ]}
-              value={channel()}
-              onChange={setChannel}
-              size="sm"
-            />
-            <Button
-              size="sm"
-              variant="primary"
-              loading={checking()}
-              leadingIcon={<RefreshCw size={13} />}
-              onClick={runCheck}
-            >
-              Check
-            </Button>
-          </div>
-        </div>
 
         <Show when={checkErr()}>
           <div class="mt-3 rounded-md border border-rose-200 bg-rose-50 p-2 text-xs text-rose-700 dark:border-rose-900/50 dark:bg-rose-950/30 dark:text-rose-400">
@@ -199,7 +213,7 @@ export default function UpdatesPanel() {
 
         <Show when={check()}>
           {(c) => (
-            <div class="mt-4">
+            <div class="mt-3">
               <Show
                 when={c().update_available}
                 fallback={
@@ -207,8 +221,8 @@ export default function UpdatesPanel() {
                     <CircleCheck size={15} />
                     <span>
                       Up to date — already on{" "}
-                      <span class="font-mono">{c().current_version}</span>{" "}
-                      ({c().channel} channel).
+                      <span class="font-mono">{c().current_version}</span> (
+                      {c().channel} channel).
                     </span>
                   </div>
                 }
@@ -248,7 +262,8 @@ export default function UpdatesPanel() {
                       Update now
                     </Button>
                     <span class="text-xs text-amber-800/70 dark:text-amber-300/70">
-                      Asset: <span class="font-mono">{c().asset_name || "n/a"}</span>
+                      Asset:{" "}
+                      <span class="font-mono">{c().asset_name || "n/a"}</span>
                     </span>
                   </div>
                 </div>
@@ -259,10 +274,14 @@ export default function UpdatesPanel() {
       </Card>
 
       <Show when={status() && status()!.state !== "idle"}>
-        <Card class="mt-4">
+        <Card class="mt-3">
           <CardHeader
             title="update progress"
-            subtitle={status()!.from ? `${status()!.from} → ${status()!.to || "?"}` : undefined}
+            subtitle={
+              status()!.from
+                ? `${status()!.from} → ${status()!.to || "?"}`
+                : undefined
+            }
           />
           <Show when={applyErr()}>
             <div class="mb-2 rounded-md border border-rose-200 bg-rose-50 p-2 text-xs text-rose-700 dark:border-rose-900/50 dark:bg-rose-950/30 dark:text-rose-400">
@@ -297,7 +316,13 @@ function StepIndicator(props: { state: UpdateState }) {
           return (
             <>
               <Show when={i() > 0}>
-                <span class={done() ? "h-px w-6 bg-emerald-400" : "h-px w-6 bg-zinc-300 dark:bg-zinc-700"} />
+                <span
+                  class={
+                    done()
+                      ? "h-px w-6 bg-emerald-400"
+                      : "h-px w-6 bg-zinc-300 dark:bg-zinc-700"
+                  }
+                />
               </Show>
               <span
                 class={
@@ -309,7 +334,11 @@ function StepIndicator(props: { state: UpdateState }) {
                 <span
                   class={
                     "h-1.5 w-1.5 rounded-full " +
-                    (active() ? "animate-pulse bg-emerald-500" : done() ? "bg-emerald-500" : "bg-zinc-400")
+                    (active()
+                      ? "animate-pulse bg-emerald-500"
+                      : done()
+                        ? "bg-emerald-500"
+                        : "bg-zinc-400")
                   }
                 />
                 {cap(label)}

--- a/internal/web/webui/src/util/clipboard.ts
+++ b/internal/web/webui/src/util/clipboard.ts
@@ -1,0 +1,37 @@
+// copyText writes `text` to the system clipboard, transparently
+// degrading to the legacy execCommand path on plain-HTTP origins where
+// `navigator.clipboard` is unavailable.
+//
+// Background: ehco's admin SPA frequently runs over plain HTTP on a
+// LAN IP (e.g. http://192.168.x.x), which is not a secure context.
+// Browsers expose `navigator.clipboard` only on HTTPS or localhost, so
+// the modern API silently rejects on the most common deployment shape.
+// `document.execCommand("copy")` is deprecated but still implemented
+// everywhere and works in non-secure contexts.
+export async function copyText(text: string): Promise<boolean> {
+  if (!text) return false;
+  if (navigator.clipboard && window.isSecureContext) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // Fall through to the legacy path; some browsers reject even
+      // in a secure context (permissions, headless, etc).
+    }
+  }
+  try {
+    const ta = document.createElement("textarea");
+    ta.value = text;
+    ta.setAttribute("readonly", "");
+    ta.style.position = "fixed";
+    ta.style.opacity = "0";
+    ta.style.pointerEvents = "none";
+    document.body.appendChild(ta);
+    ta.select();
+    const ok = document.execCommand("copy");
+    document.body.removeChild(ta);
+    return ok;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a self-contained, dependency-free observability layer over the local SQLite metrics store, embedded directly in ehco's own admin SPA. No external Prometheus / OTel collector — ehco does it all itself.

**Three new cards in Settings:**
- **Storage** — file size, pages, freelist (with VACUUM hint when fragmentation > 30%), row counts, last rule write age. Calls out an empty `rule_metrics` table inline so a broken sync pipeline is visible.
- **Query Latency** — count / avg / max / last per op (`add_node`, `add_rule`, `query_node`, `query_rule`, `cleanup`, `vacuum`, `truncate`), since process start. Reset button.
- **Maintenance** — Clean older-than-N-days · VACUUM · Truncate (literal-match confirm).

## Design notes

- **No third-party libs.** ~80 LoC for stats, ~10 LoC PRAGMA per metric. The `track(*opStats) func()` helper is the only instrumentation shape — every public ms method ends with one `defer track(&ms.stats.X)()` line.
- **Row count is `atomic.Int64`-cached.** Avoids `SELECT COUNT(*)` on every Settings refresh; reconciled by `recountRows()` after Vacuum/Truncate and at startup. INSERT OR REPLACE can briefly overcount on duplicate PKs — bounded, doc'd, self-healing.
- **Truncate requires `confirm == "yes I am sure"` exactly** (string, not bool — a defaulted JSON field can never wipe data).
- **Vacuum is synchronous.** Current ~2.5MB db: <100ms. Past ~1GB: lock window stretches into seconds; SPA confirm copy mentions this.
- **All maintenance ops auth-gated** by the existing `/api/v1` echo group middleware — confirm strings are a second line of defence, not the first.

## API surface

```
GET  /api/v1/db/health
POST /api/v1/db/cleanup       {older_than_days: int}
POST /api/v1/db/vacuum
POST /api/v1/db/truncate      {confirm: "yes I am sure"}
POST /api/v1/db/reset_stats
```

When the underlying store is disabled (no upstream sync URL), every endpoint returns 503 via `cmgr.ErrMetricsDisabled`.

## Test plan

- [x] `go test -race ./internal/cmgr/ms/...` — round-trip, cleanup, truncate strictness, reset (all PASS)
- [x] `make lint` clean
- [x] `make test` full suite green
- [x] `make ui` builds (Vite OK, +~3KB gzipped)
- [ ] Smoke on a live node: hit each endpoint, verify Settings cards render, confirm `rule_metrics=0` warning shows on the boxes that surfaced in the original investigation
- [ ] Watch latency card under load — sanity-check that `add_node` p~max stays sub-ms on real traffic

## Why

Direct outcome of investigating PR #443's "SQLite 撑不住" claim. Probing a real node showed: 2.5MB db, all queries <1ms, but `rule_metrics` empty (separate sync-pipeline bug). Decision: stay on SQLite long-term; build observability so future "撑不住" judgements are data-driven, and surface the empty-table case loudly so the underlying bug doesn't hide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)