### PR TITLE
fix(updater): detect nightly tag republish

### DIFF
--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -24,6 +24,6 @@ var UpdateCMD = &cli.Command{
 			Channel: c.String("channel"),
 			Force:   c.Bool("force"),
 			Restart: !c.Bool("no-restart"),
-		}, constant.Version, cliLogger, nil)
+		}, constant.Version, constant.BuildTime, cliLogger, nil)
 	},
 }

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -80,7 +80,8 @@ type ghRelease struct {
 }
 
 // Check resolves channel against currentVersion and queries GitHub.
-func Check(ctx context.Context, channel, currentVersion string) (*CheckResult, error) {
+// currentBuildTime is the ldflag-injected constant.BuildTime; empty is fine.
+func Check(ctx context.Context, channel, currentVersion, currentBuildTime string) (*CheckResult, error) {
 	resolved, rel, err := pickRelease(ctx, channel, currentVersion)
 	if err != nil {
 		return nil, err
@@ -96,7 +97,11 @@ func Check(ctx context.Context, channel, currentVersion string) (*CheckResult, e
 		ReleaseURL:     rel.HTMLURL,
 		PublishedAt:    rel.PublishedAt,
 	}
-	res.UpdateAvailable = latest != currentVersion && compareVersions(latest, currentVersion) > 0
+	if latest == currentVersion {
+		res.UpdateAvailable = nightlyRepublished(rel, currentBuildTime)
+	} else {
+		res.UpdateAvailable = compareVersions(latest, currentVersion) > 0
+	}
 	if a := pickAsset(rel.Assets); a != nil {
 		res.AssetName = a.Name
 		res.AssetURL = a.BrowserDownloadURL
@@ -106,7 +111,7 @@ func Check(ctx context.Context, channel, currentVersion string) (*CheckResult, e
 
 // Apply downloads + swaps + (optionally) restarts. Each phase is reported
 // to onState so the dashboard can render progress; CLI passes nil.
-func Apply(ctx context.Context, opts ApplyOptions, currentVersion string, log *zap.SugaredLogger, onState func(State)) error {
+func Apply(ctx context.Context, opts ApplyOptions, currentVersion, currentBuildTime string, log *zap.SugaredLogger, onState func(State)) error {
 	emit := func(s State) {
 		if onState != nil {
 			onState(s)
@@ -123,11 +128,15 @@ func Apply(ctx context.Context, opts ApplyOptions, currentVersion string, log *z
 
 	if !opts.Force {
 		if latest == currentVersion {
-			log.Info("already up to date")
-			emit(StateDone)
-			return nil
-		}
-		if compareVersions(latest, currentVersion) < 0 {
+			if nightlyRepublished(rel, currentBuildTime) {
+				log.Infof("nightly tag %s republished after local build (%s); reinstalling",
+					rel.TagName, currentBuildTime)
+			} else {
+				log.Info("already up to date")
+				emit(StateDone)
+				return nil
+			}
+		} else if compareVersions(latest, currentVersion) < 0 {
 			return fmt.Errorf("refusing to downgrade %s -> %s; use force", currentVersion, latest)
 		}
 	}
@@ -257,6 +266,33 @@ func getJSON(ctx context.Context, url string, out any) error {
 		return fmt.Errorf("github %s: %s", resp.Status, strings.TrimSpace(string(body)))
 	}
 	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+// nightlyRepublished reports whether a release whose tag matches the
+// running version is actually newer than the current binary. Nightly
+// uses a rolling tag (v1.1.7-next), so version-string equality alone
+// would mask republished builds. Only meaningful for prereleases; stable
+// tags don't roll.
+func nightlyRepublished(rel *ghRelease, currentBuildTime string) bool {
+	if !rel.Prerelease || currentBuildTime == "" {
+		return false
+	}
+	built, ok := parseBuildTime(currentBuildTime)
+	if !ok {
+		return false
+	}
+	return rel.PublishedAt.After(built)
+}
+
+// parseBuildTime accepts both ldflag formats: goreleaser's RFC3339
+// ({{.Date}}) and the Makefile's "2006-01-02-15:04:05".
+func parseBuildTime(s string) (time.Time, bool) {
+	for _, layout := range []string{time.RFC3339, "2006-01-02-15:04:05"} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
 }
 
 // compareVersions returns -1/0/1 like semver.Compare. Falls back to

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -1,6 +1,9 @@
 package updater
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestResolveChannel(t *testing.T) {
 	cases := []struct {
@@ -41,6 +44,49 @@ func TestCompareVersions(t *testing.T) {
 	for _, c := range cases {
 		if got := compareVersions(c.a, c.b); got != c.want {
 			t.Errorf("compareVersions(%q,%q)=%d want %d", c.a, c.b, got, c.want)
+		}
+	}
+}
+
+func TestParseBuildTime(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"2026-05-04T23:10:16Z", true},                   // goreleaser
+		{"2026-05-04T23:10:16+08:00", true},              // RFC3339 w/ offset
+		{"2026-05-04-23:10:16", true},                    // Makefile
+		{"", false},
+		{"not-a-time", false},
+	}
+	for _, c := range cases {
+		_, ok := parseBuildTime(c.in)
+		if ok != c.want {
+			t.Errorf("parseBuildTime(%q) ok=%v want %v", c.in, ok, c.want)
+		}
+	}
+}
+
+func TestNightlyRepublished(t *testing.T) {
+	built := "2026-05-04T23:10:16Z"
+	older := time.Date(2026, 5, 4, 22, 0, 0, 0, time.UTC)
+	newer := time.Date(2026, 5, 5, 6, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name       string
+		rel        ghRelease
+		buildTime  string
+		want       bool
+	}{
+		{"prerelease republished after build", ghRelease{Prerelease: true, PublishedAt: newer}, built, true},
+		{"prerelease same/older than build", ghRelease{Prerelease: true, PublishedAt: older}, built, false},
+		{"stable release ignored", ghRelease{Prerelease: false, PublishedAt: newer}, built, false},
+		{"empty build time -> conservative false", ghRelease{Prerelease: true, PublishedAt: newer}, "", false},
+		{"unparseable build time -> false", ghRelease{Prerelease: true, PublishedAt: newer}, "garbage", false},
+	}
+	for _, c := range cases {
+		if got := nightlyRepublished(&c.rel, c.buildTime); got != c.want {
+			t.Errorf("%s: got %v want %v", c.name, got, c.want)
 		}
 	}
 }

--- a/internal/web/handler_update.go
+++ b/internal/web/handler_update.go
@@ -54,7 +54,7 @@ func (s *Server) UpdateCheck(c echo.Context) error {
 	}
 	ctx, cancel := context.WithTimeout(c.Request().Context(), 30*time.Second)
 	defer cancel()
-	res, err := updater.Check(ctx, channel, constant.Version)
+	res, err := updater.Check(ctx, channel, constant.Version, constant.BuildTime)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadGateway, err.Error())
 	}
@@ -105,7 +105,7 @@ func (s *Server) runUpdate(opts updater.ApplyOptions, job *JobStatus) {
 		*job = next
 	}
 
-	if err := updater.Apply(ctx, opts, constant.Version, s.l, onState); err != nil {
+	if err := updater.Apply(ctx, opts, constant.Version, constant.BuildTime, s.l, onState); err != nil {
 		next := *job
 		next.State = updater.StateFailed
 		next.Error = err.Error()


### PR DESCRIPTION
## Summary
- Nightly uses a rolling tag (`v1.1.7-next`), so version-string equality made `updater.Check`/`Apply` short-circuit to "already up to date" even after a fresh nightly release.
- Compare release `published_at` against the local ldflag-injected `BuildTime` to detect republished nightly builds. Stable channel is unaffected.
- Accepts both ldflag formats: goreleaser RFC3339 (`{{.Date}}`) and Makefile `2006-01-02-15:04:05`. Empty / unparseable BuildTime falls back to `false` so bare `go build` doesn't trigger false positives.

## Test plan
- [x] `go test ./internal/updater/... -count=1` (added `TestParseBuildTime`, `TestNightlyRepublished`)
- [x] `make lint`
- [ ] Deploy to a node, click `Check` in the dashboard against the latest republished nightly — should show update available; `Apply` should proceed and restart cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)